### PR TITLE
feat: add partial replacement of _.pick

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export * from './utils/is-not-null-or-undefined';
 
 export * from './utils/chunk';
 export * from './utils/flatten';
+export * from './utils/pick';
 export * from './utils/pluck';
 export * from './utils/delay';
 export * from './utils/get';

--- a/src/utils/pick.ts
+++ b/src/utils/pick.ts
@@ -1,0 +1,24 @@
+import { isArray } from './is-array';
+
+// NOTE: If changing these types, ensure the following cases cause a type error:
+//
+// const noProps = pick({ a: 1 });
+//
+// noProps.a; // Property 'a' does not exist on type 'Pick<{ a: number; }, never>'.
+//
+// const emptyArr = pick({ a: 1 }, []);
+//
+// emptyArr.a; // Property 'a' does not exist on type 'Pick<{ a: number; }, never>'.
+
+export function pick<T extends object, K extends keyof T>(obj: T, props: K[]): Pick<T, K>;
+export function pick<T extends object, K extends keyof T = never>(obj: T, ...props: K[]): Pick<T, K>;
+export function pick<T extends object, K extends keyof T>(obj: T, ...args: K[] | [ K[] ]): Pick<T, K> {
+   const props = ((args.length === 1 && isArray(args[0])) ? args[0] : args) as K[];
+
+   return props.reduce((memo, prop) => {
+      if (prop in obj) {
+         memo[prop] = obj[prop];
+      }
+      return memo;
+   }, {} as Pick<T, K>);
+}

--- a/tests/utils/pick.test.ts
+++ b/tests/utils/pick.test.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import { pick } from '../../src';
+
+interface Location {
+   city: string;
+   state: string;
+}
+
+interface Person {
+   firstName: string;
+   middleInitial?: string;
+   lastName: string;
+   age: number;
+   location?: Location;
+}
+
+const JOHN_DOE: Person = { firstName: 'John', lastName: 'Doe', age: 21 },
+      JANE_DOE: Person = { firstName: 'Jane', lastName: 'Doe', age: 22, location: { city: 'New York', state: 'NY' } };
+
+const WILE_E_COYOTE: Person = {
+   firstName: 'Wile',
+   middleInitial: 'E',
+   lastName: 'Coyote',
+   age: 12,
+   location: { city: 'Tucson', state: 'AZ' },
+};
+
+describe('pick', () => {
+
+   it('doesn\'t modify the source object', () => {
+      const orig = { firstName: 'John', lastName: 'Doe', age: 21 };
+
+      expect(pick(orig, 'age')).to.eql({ age: 21 });
+      expect(orig).to.eql({ firstName: 'John', lastName: 'Doe', age: 21 });
+   });
+
+   it('works correctly when passed an array of keys', () => {
+      // Explicitly type the results so we can make sure that our types on pick are
+      // implemented correctly.
+      const onlyAge: Pick<Person, 'age'> = pick(JOHN_DOE, [ 'age' ]),
+            firstNameAndAge: Pick<Person, 'firstName' | 'age'> = pick(JOHN_DOE, [ 'firstName', 'age' ]),
+            requiredProps: Person = pick(WILE_E_COYOTE, [ 'firstName', 'lastName', 'age' ]),
+            noProps: {} = pick(JOHN_DOE);
+
+      const oneRequiredOneUndefinedOneOptional: Pick<Person, 'firstName' | 'middleInitial' | 'location'> = pick(JANE_DOE, [
+         'firstName',
+         'middleInitial',
+         'location',
+      ]);
+
+      expect(onlyAge).to.eql({ age: 21 });
+      expect(firstNameAndAge).to.eql({ firstName: 'John', age: 21 });
+      expect(requiredProps).to.eql({ firstName: 'Wile', lastName: 'Coyote', age: 12 });
+      expect(noProps).to.eql({});
+      expect(oneRequiredOneUndefinedOneOptional).to.eql({ firstName: 'Jane', location: { city: 'New York', state: 'NY' } });
+   });
+
+   it('works correctly when called using a variadic syntax', () => {
+      // Explicitly type the results so we can make sure that our types on pick are
+      // implemented correctly.
+      const onlyAge: Pick<Person, 'age'> = pick(JOHN_DOE, 'age'),
+            firstNameAndAge: Pick<Person, 'firstName' | 'age'> = pick(JOHN_DOE, 'firstName', 'age'),
+            requiredProps: Person = pick(WILE_E_COYOTE, 'firstName', 'lastName', 'age'),
+            noProps: {} = pick(JOHN_DOE, []);
+
+      const oneRequiredOneUndefinedOneOptional: Pick<Person, 'firstName' | 'middleInitial' | 'location'> = pick(
+         JANE_DOE,
+         'firstName',
+         'middleInitial',
+         'location'
+      );
+
+      expect(onlyAge).to.eql({ age: 21 });
+      expect(firstNameAndAge).to.eql({ firstName: 'John', age: 21 });
+      expect(requiredProps).to.eql({ firstName: 'Wile', lastName: 'Coyote', age: 12 });
+      expect(noProps).to.eql({});
+      expect(oneRequiredOneUndefinedOneOptional).to.eql({ firstName: 'Jane', location: { city: 'New York', state: 'NY' } });
+   });
+
+   it('picks properties set to undefined', () => {
+      const obj: { undefinedVal?: string; unsetVal?: string } = { undefinedVal: undefined };
+
+      expect(pick(obj, 'undefinedVal')).to.eql({ undefinedVal: undefined });
+      expect(pick(obj, 'unsetVal')).to.eql({});
+   });
+
+   it('can pick functions from a class prototype', () => {
+      class Sample {
+         public testMethod(): void {}
+      }
+
+      expect(pick(new Sample(), 'testMethod')).to.eql({ testMethod: Sample.prototype.testMethod });
+   });
+
+   it('can pick properties from the object\'s prototype', () => {
+      const objWithProto = { a: 1 } as { a: number; b: number };
+
+      (objWithProto as any).__proto__ = { b: 2 }; // eslint-disable-line no-proto
+
+      expect(objWithProto.b).to.strictlyEqual(2);
+      expect(pick(objWithProto, 'b')).to.eql({ b: 2 });
+   });
+
+});


### PR DESCRIPTION
While object destructuring has removed most of the need for a `pick` function, object
destructuring becomes rather unwieldy when trying to pick a large number of properties.
In that case, using a `pick` function makes the code more readable. Since underscore's
typing just returns `any`, adding a type safe `pick`.

NOTE: This doesn't support passing a function which determines the properties to pick as
underscore does. However, there doesn't seem to be a good way to make that behavior type
safe, so not attempting to support it at this time.