### PR TITLE
chore: upgrade @silvermine/standardization and configuration

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+   "extends": "./node_modules/@silvermine/standardization/.markdownlint.json"
+}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-node_modules/@silvermine/standardization/.nvmrc
+12.22.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-   - "node" # Latest node version
+   # TODO: Re-enable when Travis CI fixes image dependency problems
+   # See: https://github.com/silvermine/standardization/issues/39
+   # - "node" # Latest node version
    - "lts/*" # Latest LTS version
    - "14"
    - "12"
@@ -12,7 +14,7 @@ before_install: npm i -g npm@6.14.12;
 script:
    - node --version
    - npm --version
-   - grunt standards
+   - npm run standards
    - commitlint-travis
    - grunt clean build
    - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
+dist: focal
 language: node_js
 node_js:
-   # TODO: Re-enable when Travis CI fixes image dependency problems
-   # See: https://github.com/silvermine/standardization/issues/39
-   # - "node" # Latest node version
+   - "node" # Latest node version
    - "lts/*" # Latest LTS version
    - "14"
    - "12"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,16 +41,6 @@ module.exports = (grunt) => {
 
       pkg: grunt.file.readJSON('package.json'),
 
-      eslint: {
-         target: [ ...config.js.all, ...config.ts.all ],
-         fix: {
-            src: [ ...config.js.all, ...config.ts.all ],
-            options: {
-               fix: true,
-            },
-         },
-      },
-
       exec: {
          options: {
             failOnError: true,
@@ -92,14 +82,11 @@ module.exports = (grunt) => {
       },
    });
 
-   grunt.loadNpmTasks('grunt-eslint');
+
    grunt.loadNpmTasks('grunt-exec');
    grunt.loadNpmTasks('grunt-contrib-clean');
    grunt.loadNpmTasks('grunt-concurrent');
    grunt.loadNpmTasks('grunt-contrib-watch');
-
-   grunt.registerTask('standards', [ 'eslint:target', 'exec:standards' ]);
-   grunt.registerTask('standards-fix', [ 'eslint:fix' ]);
 
    grunt.registerTask('build-types', [ 'exec:types' ]);
    grunt.registerTask('build-esm', [ 'exec:esm' ]);
@@ -108,6 +95,4 @@ module.exports = (grunt) => {
    grunt.registerTask('build', [ 'concurrent:build-ts-outputs' ]);
 
    grunt.registerTask('develop', [ 'clean:dist', 'build', 'watch' ]);
-
-   grunt.registerTask('default', [ 'standards' ]);
 };

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-<p align="center">
-  <img width="300" height="300" src="https://raw.github.com/silvermine/toolbox/master/src/logo/toolbox.png" alt="Tools such as a protractor, calculator, pencil, and a pen inside a shirt pocket.">
-</p>
-
 # Silvermine Toolbox - TypeScript Types and Utilities
+
+<p align="center">
+   <img width="300"
+    height="300"
+    src="https://raw.github.com/silvermine/toolbox/master/src/logo/toolbox.png"
+    alt="Tools such as a protractor, calculator, pencil, and a pen inside a shirt pocket."
+   >
+</p>
 
 [![NPM Version](https://img.shields.io/npm/v/@silvermine/toolbox.svg)](https://www.npmjs.com/package/@silvermine/toolbox)
 [![License](https://img.shields.io/github/license/silvermine/toolbox.svg)](./LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -769,12 +769,6 @@
                "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                "dev": true
             },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            },
             "parse-json": {
                "version": "5.2.0",
                "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -864,22 +858,7 @@
          "requires": {
             "@commitlint/types": "^12.1.4",
             "lodash": "^4.17.19"
-         },
-         "dependencies": {
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            }
          }
-      },
-      "@commitlint/execute-rule": {
-         "version": "8.3.4",
-         "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-8.3.4.tgz",
-         "integrity": "sha512-f4HigYjeIBn9f7OuNv5zh2y5vWaAhNFrfeul8CRJDy82l3Y+09lxOTGxfF3uMXKrZq4LmuK6qvvRCZ8mUrVvzQ==",
-         "dev": true,
-         "optional": true
       },
       "@commitlint/format": {
          "version": "12.1.4",
@@ -975,43 +954,6 @@
             "@commitlint/types": "^12.1.4"
          }
       },
-      "@commitlint/load": {
-         "version": "8.3.5",
-         "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-8.3.5.tgz",
-         "integrity": "sha512-poF7R1CtQvIXRmVIe63FjSQmN9KDqjRtU5A6hxqXBga87yB2VUJzic85TV6PcQc+wStk52cjrMI+g0zFx+Zxrw==",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "@commitlint/execute-rule": "^8.3.4",
-            "@commitlint/resolve-extends": "^8.3.5",
-            "babel-runtime": "^6.23.0",
-            "chalk": "2.4.2",
-            "cosmiconfig": "^5.2.0",
-            "lodash": "4.17.15",
-            "resolve-from": "^5.0.0"
-         },
-         "dependencies": {
-            "chalk": {
-               "version": "2.4.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-               "dev": true,
-               "optional": true,
-               "requires": {
-                  "ansi-styles": "^3.2.1",
-                  "escape-string-regexp": "^1.0.5",
-                  "supports-color": "^5.3.0"
-               }
-            },
-            "lodash": {
-               "version": "4.17.15",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-               "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-               "dev": true,
-               "optional": true
-            }
-         }
-      },
       "@commitlint/message": {
          "version": "12.1.4",
          "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-12.1.4.tgz",
@@ -1074,28 +1016,6 @@
                "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
                "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
                "dev": true
-            }
-         }
-      },
-      "@commitlint/resolve-extends": {
-         "version": "8.3.5",
-         "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-8.3.5.tgz",
-         "integrity": "sha512-nHhFAK29qiXNe6oH6uG5wqBnCR+BQnxlBW/q5fjtxIaQALgfoNLHwLS9exzbIRFqwJckpR6yMCfgMbmbAOtklQ==",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "import-fresh": "^3.0.0",
-            "lodash": "4.17.15",
-            "resolve-from": "^5.0.0",
-            "resolve-global": "^1.0.0"
-         },
-         "dependencies": {
-            "lodash": {
-               "version": "4.17.15",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-               "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-               "dev": true,
-               "optional": true
             }
          }
       },
@@ -1241,111 +1161,10 @@
             }
          }
       },
-      "@eslint/eslintrc": {
-         "version": "1.0.5",
-         "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
-         "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
-         "dev": true,
-         "requires": {
-            "ajv": "^6.12.4",
-            "debug": "^4.3.2",
-            "espree": "^9.2.0",
-            "globals": "^13.9.0",
-            "ignore": "^4.0.6",
-            "import-fresh": "^3.2.1",
-            "js-yaml": "^4.1.0",
-            "minimatch": "^3.0.4",
-            "strip-json-comments": "^3.1.1"
-         },
-         "dependencies": {
-            "acorn": {
-               "version": "8.7.0",
-               "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-               "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-               "dev": true
-            },
-            "ajv": {
-               "version": "6.12.6",
-               "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-               "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-               "dev": true,
-               "requires": {
-                  "fast-deep-equal": "^3.1.1",
-                  "fast-json-stable-stringify": "^2.0.0",
-                  "json-schema-traverse": "^0.4.1",
-                  "uri-js": "^4.2.2"
-               }
-            },
-            "argparse": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-               "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-               "dev": true
-            },
-            "eslint-visitor-keys": {
-               "version": "3.2.0",
-               "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-               "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-               "dev": true
-            },
-            "espree": {
-               "version": "9.3.0",
-               "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-               "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
-               "dev": true,
-               "requires": {
-                  "acorn": "^8.7.0",
-                  "acorn-jsx": "^5.3.1",
-                  "eslint-visitor-keys": "^3.1.0"
-               }
-            },
-            "globals": {
-               "version": "13.12.1",
-               "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-               "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-               "dev": true,
-               "requires": {
-                  "type-fest": "^0.20.2"
-               }
-            },
-            "js-yaml": {
-               "version": "4.1.0",
-               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-               "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-               "dev": true,
-               "requires": {
-                  "argparse": "^2.0.1"
-               }
-            },
-            "strip-json-comments": {
-               "version": "3.1.1",
-               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-               "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-               "dev": true
-            },
-            "type-fest": {
-               "version": "0.20.2",
-               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-               "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-               "dev": true
-            }
-         }
-      },
-      "@humanwhocodes/config-array": {
-         "version": "0.9.3",
-         "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
-         "integrity": "sha512-3xSMlXHh03hCcCmFc0rbKp3Ivt2PFEJnQUJDDMTJQ2wkECZWdq4GePs2ctc5H8zV+cHPaq8k2vU8mrQjA6iHdQ==",
-         "dev": true,
-         "requires": {
-            "@humanwhocodes/object-schema": "^1.2.1",
-            "debug": "^4.1.1",
-            "minimatch": "^3.0.4"
-         }
-      },
-      "@humanwhocodes/object-schema": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-         "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "@hutson/parse-repository-url": {
+         "version": "3.0.2",
+         "resolved": "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz",
+         "integrity": "sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==",
          "dev": true
       },
       "@jridgewell/resolve-uri": {
@@ -1435,18 +1254,22 @@
          }
       },
       "@silvermine/standardization": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-1.2.1.tgz",
-         "integrity": "sha512-nm8tmUTPTYTlEfK4LDOK1kBc/+HnBLMNiHPtP8RMwrlGzCNjFGfEaR1rKmWqMZ90lR17Vc2+G079TiFlvIieAw==",
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/@silvermine/standardization/-/standardization-2.0.0.tgz",
+         "integrity": "sha512-F1kVMa6EeTrN3xRM1FkEwjJw8lE2qp0Dvpfrtjg7F43Msm+Vv0fnwnygcjSzEzFNaVrPGHptugiod+u1U8+JFA==",
          "dev": true,
          "requires": {
             "@commitlint/cli": "12.1.1",
             "@commitlint/travis-cli": "12.1.1",
+            "chalk": "4.1.2",
             "check-node-version": "4.0.3",
-            "grunt-markdownlint": "2.9.0",
-            "grunt-stylelint": "0.16.0",
-            "markdownlint": "0.19.0",
-            "markdownlint-cli": "0.28.1",
+            "commander": "9.0.0",
+            "conventional-changelog": "3.1.25",
+            "conventional-changelog-conventionalcommits": "4.6.3",
+            "conventional-recommended-bump": "6.1.0",
+            "git-semver-tags": "4.1.1",
+            "markdownlint-cli": "0.31.1",
+            "semver": "7.3.5",
             "stylelint": "13.13.1",
             "stylelint-config-standard": "22.0.0",
             "stylelint-scss": "3.19.0"
@@ -1462,9 +1285,9 @@
                }
             },
             "chalk": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-               "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+               "version": "4.1.2",
+               "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+               "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
                "dev": true,
                "requires": {
                   "ansi-styles": "^4.1.0",
@@ -1483,6 +1306,24 @@
                   "object-filter": "^1.0.2",
                   "run-parallel": "^1.1.4",
                   "semver": "^6.3.0"
+               },
+               "dependencies": {
+                  "chalk": {
+                     "version": "3.0.0",
+                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                     "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+                     "dev": true,
+                     "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                     }
+                  },
+                  "semver": {
+                     "version": "6.3.0",
+                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                     "dev": true
+                  }
                }
             },
             "color-convert": {
@@ -1500,17 +1341,83 @@
                "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                "dev": true
             },
+            "commander": {
+               "version": "9.0.0",
+               "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+               "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+               "dev": true
+            },
+            "concat-stream": {
+               "version": "2.0.0",
+               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+               "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+               "dev": true,
+               "requires": {
+                  "buffer-from": "^1.0.0",
+                  "inherits": "^2.0.3",
+                  "readable-stream": "^3.0.2",
+                  "typedarray": "^0.0.6"
+               }
+            },
+            "conventional-recommended-bump": {
+               "version": "6.1.0",
+               "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-6.1.0.tgz",
+               "integrity": "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw==",
+               "dev": true,
+               "requires": {
+                  "concat-stream": "^2.0.0",
+                  "conventional-changelog-preset-loader": "^2.3.4",
+                  "conventional-commits-filter": "^2.0.7",
+                  "conventional-commits-parser": "^3.2.0",
+                  "git-raw-commits": "^2.0.8",
+                  "git-semver-tags": "^4.1.1",
+                  "meow": "^8.0.0",
+                  "q": "^1.5.1"
+               }
+            },
+            "git-semver-tags": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+               "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
+               "dev": true,
+               "requires": {
+                  "meow": "^8.0.0",
+                  "semver": "^6.0.0"
+               },
+               "dependencies": {
+                  "semver": {
+                     "version": "6.3.0",
+                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                     "dev": true
+                  }
+               }
+            },
             "has-flag": {
                "version": "4.0.0",
                "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                "dev": true
             },
+            "readable-stream": {
+               "version": "3.6.0",
+               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+               "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+               "dev": true,
+               "requires": {
+                  "inherits": "^2.0.3",
+                  "string_decoder": "^1.1.1",
+                  "util-deprecate": "^1.0.1"
+               }
+            },
             "semver": {
-               "version": "6.3.0",
-               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-               "dev": true
+               "version": "7.3.5",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+               "dev": true,
+               "requires": {
+                  "lru-cache": "^6.0.0"
+               }
             },
             "supports-color": {
                "version": "7.2.0",
@@ -1722,12 +1629,6 @@
                   "path-is-absolute": "^1.0.0"
                }
             },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            },
             "semver": {
                "version": "6.3.0",
                "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1764,6 +1665,12 @@
          "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
          "dev": true
       },
+      "add-stream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+         "integrity": "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==",
+         "dev": true
+      },
       "ajv": {
          "version": "6.11.0",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
@@ -1775,18 +1682,6 @@
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.2"
          }
-      },
-      "ansi-escapes": {
-         "version": "3.2.0",
-         "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-         "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-         "dev": true
-      },
-      "ansi-regex": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-         "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-         "dev": true
       },
       "ansi-styles": {
          "version": "3.2.1",
@@ -1964,17 +1859,6 @@
          "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
          "dev": true
       },
-      "babel-runtime": {
-         "version": "6.26.0",
-         "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-         "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-         }
-      },
       "bail": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -2150,63 +2034,11 @@
             "unset-value": "^1.0.0"
          }
       },
-      "cachedir": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.2.0.tgz",
-         "integrity": "sha512-VvxA0xhNqIIfg0V9AmJkDg91DaJwryutH5rVEZAhcNi4iJFj9f+QxmAjgK1LT9I8OgToX27fypX6/MeCXVbBjQ==",
-         "dev": true
-      },
-      "caller-callsite": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-         "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "callsites": "^2.0.0"
-         },
-         "dependencies": {
-            "callsites": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-               "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-               "dev": true,
-               "optional": true
-            }
-         }
-      },
-      "caller-path": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-         "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "caller-callsite": "^2.0.0"
-         }
-      },
       "callsites": {
          "version": "3.1.0",
          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
          "dev": true
-      },
-      "camelcase": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-         "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-         "dev": true
-      },
-      "camelcase-keys": {
-         "version": "4.2.0",
-         "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-         "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-         "dev": true,
-         "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
-         }
       },
       "caniuse-lite": {
          "version": "1.0.30001312",
@@ -2376,32 +2208,6 @@
          "integrity": "sha1-tO5BfGk3QKRKkqbWTxyVQGQbCXo=",
          "dev": true
       },
-      "cli-cursor": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-         "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-         "dev": true,
-         "requires": {
-            "restore-cursor": "^2.0.0"
-         }
-      },
-      "cli-width": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-         "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-         "dev": true
-      },
-      "cliui": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-         "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-         "dev": true,
-         "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-         }
-      },
       "clone-regexp": {
          "version": "2.2.0",
          "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
@@ -2410,12 +2216,6 @@
          "requires": {
             "is-regexp": "^2.0.0"
          }
-      },
-      "code-point-at": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-         "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-         "dev": true
       },
       "coffeescript": {
          "version": "1.10.0",
@@ -2469,103 +2269,14 @@
          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
          "dev": true
       },
-      "commitizen": {
-         "version": "4.0.3",
-         "resolved": "https://registry.npmjs.org/commitizen/-/commitizen-4.0.3.tgz",
-         "integrity": "sha512-lxu0F/Iq4dudoFeIl5pY3h3CQJzkmQuh3ygnaOvqhAD8Wu2pYBI17ofqSuPHNsBTEOh1r1AVa9kR4Hp0FAHKcQ==",
-         "dev": true,
-         "requires": {
-            "cachedir": "2.2.0",
-            "cz-conventional-changelog": "3.0.1",
-            "dedent": "0.7.0",
-            "detect-indent": "6.0.0",
-            "find-node-modules": "2.0.0",
-            "find-root": "1.1.0",
-            "fs-extra": "8.1.0",
-            "glob": "7.1.4",
-            "inquirer": "6.5.0",
-            "is-utf8": "^0.2.1",
-            "lodash": "4.17.15",
-            "minimist": "1.2.0",
-            "shelljs": "0.7.6",
-            "strip-bom": "4.0.0",
-            "strip-json-comments": "3.0.1"
-         },
-         "dependencies": {
-            "chalk": {
-               "version": "2.4.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^3.2.1",
-                  "escape-string-regexp": "^1.0.5",
-                  "supports-color": "^5.3.0"
-               }
-            },
-            "conventional-commit-types": {
-               "version": "2.3.0",
-               "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-2.3.0.tgz",
-               "integrity": "sha512-6iB39PrcGYdz0n3z31kj6/Km6mK9hm9oMRhwcLnKxE7WNoeRKZbTAobliKrbYZ5jqyCvtcVEfjCiaEzhL3AVmQ==",
-               "dev": true
-            },
-            "cz-conventional-changelog": {
-               "version": "3.0.1",
-               "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.0.1.tgz",
-               "integrity": "sha512-7KASIwB8/ClEyCRvQrCPbN7WkQnUSjSSVNyPM+gDJ0jskLi8h8N2hrdpyeCk7fIqKMRzziqVSOBTB8yyLTMHGQ==",
-               "dev": true,
-               "requires": {
-                  "@commitlint/load": ">6.1.1",
-                  "chalk": "^2.4.1",
-                  "conventional-commit-types": "^2.0.0",
-                  "lodash.map": "^4.5.1",
-                  "longest": "^2.0.1",
-                  "right-pad": "^1.0.1",
-                  "word-wrap": "^1.0.3"
-               }
-            },
-            "detect-indent": {
-               "version": "6.0.0",
-               "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
-               "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
-               "dev": true
-            },
-            "glob": {
-               "version": "7.1.4",
-               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-               "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-               "dev": true,
-               "requires": {
-                  "fs.realpath": "^1.0.0",
-                  "inflight": "^1.0.4",
-                  "inherits": "2",
-                  "minimatch": "^3.0.4",
-                  "once": "^1.3.0",
-                  "path-is-absolute": "^1.0.0"
-               }
-            },
-            "lodash": {
-               "version": "4.17.15",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-               "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-               "dev": true
-            },
-            "strip-bom": {
-               "version": "4.0.0",
-               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-               "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-               "dev": true
-            }
-         }
-      },
       "compare-func": {
-         "version": "1.3.2",
-         "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.2.tgz",
-         "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+         "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
          "dev": true,
          "requires": {
             "array-ify": "^1.0.0",
-            "dot-prop": "^3.0.0"
+            "dot-prop": "^5.1.0"
          }
       },
       "component-emitter": {
@@ -2580,18 +2291,6 @@
          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
          "dev": true
       },
-      "concat-stream": {
-         "version": "1.6.2",
-         "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-         "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-         "dev": true,
-         "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-         }
-      },
       "continuable-cache": {
          "version": "0.3.1",
          "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
@@ -2599,33 +2298,22 @@
          "dev": true
       },
       "conventional-changelog": {
-         "version": "3.0.6",
-         "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.0.6.tgz",
-         "integrity": "sha512-1b96x3G67lDKakRvMm+VvYGwgRk+C8aapHKL5iZ/TJzzD/RuyGA2diHNEsR+uPHmQ7/A4Ts7j6N+VNqUoOfksg==",
+         "version": "3.1.25",
+         "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.25.tgz",
+         "integrity": "sha512-ryhi3fd1mKf3fSjbLXOfK2D06YwKNic1nC9mWqybBHdObPd8KJ2vjaXZfYj1U23t+V8T8n0d7gwnc9XbIdFbyQ==",
          "dev": true,
          "requires": {
-            "conventional-changelog-angular": "^5.0.3",
-            "conventional-changelog-atom": "^2.0.1",
-            "conventional-changelog-codemirror": "^2.0.1",
-            "conventional-changelog-core": "^3.1.6",
-            "conventional-changelog-ember": "^2.0.2",
-            "conventional-changelog-eslint": "^3.0.1",
-            "conventional-changelog-express": "^2.0.1",
-            "conventional-changelog-jquery": "^3.0.4",
-            "conventional-changelog-jshint": "^2.0.1",
-            "conventional-changelog-preset-loader": "^2.0.2"
-         },
-         "dependencies": {
-            "conventional-changelog-angular": {
-               "version": "5.0.3",
-               "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.3.tgz",
-               "integrity": "sha512-YD1xzH7r9yXQte/HF9JBuEDfvjxxwDGGwZU1+ndanbY0oFgA+Po1T9JDSpPLdP0pZT6MhCAsdvFKC4TJ4MTJTA==",
-               "dev": true,
-               "requires": {
-                  "compare-func": "^1.3.1",
-                  "q": "^1.5.1"
-               }
-            }
+            "conventional-changelog-angular": "^5.0.12",
+            "conventional-changelog-atom": "^2.0.8",
+            "conventional-changelog-codemirror": "^2.0.8",
+            "conventional-changelog-conventionalcommits": "^4.5.0",
+            "conventional-changelog-core": "^4.2.1",
+            "conventional-changelog-ember": "^2.0.9",
+            "conventional-changelog-eslint": "^3.0.9",
+            "conventional-changelog-express": "^2.0.6",
+            "conventional-changelog-jquery": "^3.0.11",
+            "conventional-changelog-jshint": "^2.0.9",
+            "conventional-changelog-preset-loader": "^2.3.4"
          }
       },
       "conventional-changelog-angular": {
@@ -2636,195 +2324,202 @@
          "requires": {
             "compare-func": "^2.0.0",
             "q": "^1.5.1"
-         },
-         "dependencies": {
-            "compare-func": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
-               "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
-               "dev": true,
-               "requires": {
-                  "array-ify": "^1.0.0",
-                  "dot-prop": "^5.1.0"
-               }
-            },
-            "dot-prop": {
-               "version": "5.3.0",
-               "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
-               "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
-               "dev": true,
-               "requires": {
-                  "is-obj": "^2.0.0"
-               }
-            },
-            "is-obj": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-               "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
-               "dev": true
-            }
          }
       },
       "conventional-changelog-atom": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.1.tgz",
-         "integrity": "sha512-9BniJa4gLwL20Sm7HWSNXd0gd9c5qo49gCi8nylLFpqAHhkFTj7NQfROq3f1VpffRtzfTQp4VKU5nxbe2v+eZQ==",
+         "version": "2.0.8",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.8.tgz",
+         "integrity": "sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-codemirror": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.1.tgz",
-         "integrity": "sha512-23kT5IZWa+oNoUaDUzVXMYn60MCdOygTA2I+UjnOMiYVhZgmVwNd6ri/yDlmQGXHqbKhNR5NoXdBzSOSGxsgIQ==",
+         "version": "2.0.8",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.8.tgz",
+         "integrity": "sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
-      "conventional-changelog-core": {
-         "version": "3.1.6",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.1.6.tgz",
-         "integrity": "sha512-5teTAZOtJ4HLR6384h50nPAaKdDr+IaU0rnD2Gg2C3MS7hKsEPH8pZxrDNqam9eOSPQg9tET6uZY79zzgSz+ig==",
+      "conventional-changelog-conventionalcommits": {
+         "version": "4.6.3",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.3.tgz",
+         "integrity": "sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==",
          "dev": true,
          "requires": {
-            "conventional-changelog-writer": "^4.0.3",
-            "conventional-commits-parser": "^3.0.1",
+            "compare-func": "^2.0.0",
+            "lodash": "^4.17.15",
+            "q": "^1.5.1"
+         }
+      },
+      "conventional-changelog-core": {
+         "version": "4.2.4",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-4.2.4.tgz",
+         "integrity": "sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==",
+         "dev": true,
+         "requires": {
+            "add-stream": "^1.0.0",
+            "conventional-changelog-writer": "^5.0.0",
+            "conventional-commits-parser": "^3.2.0",
             "dateformat": "^3.0.0",
-            "get-pkg-repo": "^1.0.0",
-            "git-raw-commits": "2.0.0",
+            "get-pkg-repo": "^4.0.0",
+            "git-raw-commits": "^2.0.8",
             "git-remote-origin-url": "^2.0.0",
-            "git-semver-tags": "^2.0.2",
-            "lodash": "^4.2.1",
-            "normalize-package-data": "^2.3.5",
+            "git-semver-tags": "^4.1.1",
+            "lodash": "^4.17.15",
+            "normalize-package-data": "^3.0.0",
             "q": "^1.5.1",
             "read-pkg": "^3.0.0",
             "read-pkg-up": "^3.0.0",
-            "through2": "^2.0.0"
+            "through2": "^4.0.0"
          },
          "dependencies": {
-            "conventional-commits-parser": {
-               "version": "3.0.1",
-               "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-               "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
-               "dev": true,
-               "requires": {
-                  "JSONStream": "^1.0.4",
-                  "is-text-path": "^1.0.0",
-                  "lodash": "^4.2.1",
-                  "meow": "^4.0.0",
-                  "split2": "^2.0.0",
-                  "through2": "^2.0.0",
-                  "trim-off-newlines": "^1.0.0"
-               }
-            },
             "dateformat": {
                "version": "3.0.3",
                "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
                "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
                "dev": true
             },
-            "git-raw-commits": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-               "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
+            "git-semver-tags": {
+               "version": "4.1.1",
+               "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-4.1.1.tgz",
+               "integrity": "sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==",
                "dev": true,
                "requires": {
-                  "dargs": "^4.0.1",
-                  "lodash.template": "^4.0.2",
-                  "meow": "^4.0.0",
-                  "split2": "^2.0.0",
-                  "through2": "^2.0.0"
+                  "meow": "^8.0.0",
+                  "semver": "^6.0.0"
                }
             },
-            "meow": {
-               "version": "4.0.1",
-               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+            "hosted-git-info": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+               "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
                "dev": true,
                "requires": {
-                  "camelcase-keys": "^4.0.0",
-                  "decamelize-keys": "^1.0.0",
-                  "loud-rejection": "^1.0.0",
-                  "minimist": "^1.1.3",
-                  "minimist-options": "^3.0.1",
-                  "normalize-package-data": "^2.3.4",
-                  "read-pkg-up": "^3.0.0",
-                  "redent": "^2.0.0",
-                  "trim-newlines": "^2.0.0"
+                  "lru-cache": "^6.0.0"
+               }
+            },
+            "normalize-package-data": {
+               "version": "3.0.3",
+               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+               "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+               "dev": true,
+               "requires": {
+                  "hosted-git-info": "^4.0.1",
+                  "is-core-module": "^2.5.0",
+                  "semver": "^7.3.4",
+                  "validate-npm-package-license": "^3.0.1"
+               },
+               "dependencies": {
+                  "semver": {
+                     "version": "7.3.7",
+                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                     "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                     "dev": true,
+                     "requires": {
+                        "lru-cache": "^6.0.0"
+                     }
+                  }
+               }
+            },
+            "readable-stream": {
+               "version": "3.6.0",
+               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+               "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+               "dev": true,
+               "requires": {
+                  "inherits": "^2.0.3",
+                  "string_decoder": "^1.1.1",
+                  "util-deprecate": "^1.0.1"
+               }
+            },
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            },
+            "through2": {
+               "version": "4.0.2",
+               "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+               "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+               "dev": true,
+               "requires": {
+                  "readable-stream": "3"
                }
             }
          }
       },
       "conventional-changelog-ember": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.2.tgz",
-         "integrity": "sha512-qtZbA3XefO/n6DDmkYywDYi6wDKNNc98MMl2F9PKSaheJ25Trpi3336W8fDlBhq0X+EJRuseceAdKLEMmuX2tg==",
+         "version": "2.0.9",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.9.tgz",
+         "integrity": "sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-eslint": {
-         "version": "3.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.1.tgz",
-         "integrity": "sha512-yH3+bYrtvgKxSFChUBQnKNh9/U9kN2JElYBm253VpYs5wXhPHVc9ENcuVGWijh24nnOkei7wEJmnmUzgZ4ok+A==",
+         "version": "3.0.9",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.9.tgz",
+         "integrity": "sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-express": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.1.tgz",
-         "integrity": "sha512-G6uCuCaQhLxdb4eEfAIHpcfcJ2+ao3hJkbLrw/jSK/eROeNfnxCJasaWdDAfFkxsbpzvQT4W01iSynU3OoPLIw==",
+         "version": "2.0.6",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.6.tgz",
+         "integrity": "sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-jquery": {
-         "version": "3.0.4",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.4.tgz",
-         "integrity": "sha512-IVJGI3MseYoY6eybknnTf9WzeQIKZv7aNTm2KQsiFVJH21bfP2q7XVjfoMibdCg95GmgeFlaygMdeoDDa+ZbEQ==",
+         "version": "3.0.11",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-3.0.11.tgz",
+         "integrity": "sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==",
          "dev": true,
          "requires": {
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-jshint": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.1.tgz",
-         "integrity": "sha512-kRFJsCOZzPFm2tzRHULWP4tauGMvccOlXYf3zGeuSW4U0mZhk5NsjnRZ7xFWrTFPlCLV+PNmHMuXp5atdoZmEg==",
+         "version": "2.0.9",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.9.tgz",
+         "integrity": "sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==",
          "dev": true,
          "requires": {
-            "compare-func": "^1.3.1",
+            "compare-func": "^2.0.0",
             "q": "^1.5.1"
          }
       },
       "conventional-changelog-preset-loader": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
-         "integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ==",
+         "version": "2.3.4",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+         "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
          "dev": true
       },
       "conventional-changelog-writer": {
-         "version": "4.0.3",
-         "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.3.tgz",
-         "integrity": "sha512-bIlpSiQtQZ1+nDVHEEh798Erj2jhN/wEjyw9sfxY9es6h7pREE5BNJjfv0hXGH/FTrAsEpHUq4xzK99eePpwuA==",
+         "version": "5.0.1",
+         "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
+         "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
          "dev": true,
          "requires": {
-            "compare-func": "^1.3.1",
-            "conventional-commits-filter": "^2.0.1",
+            "conventional-commits-filter": "^2.0.7",
             "dateformat": "^3.0.0",
-            "handlebars": "^4.1.0",
+            "handlebars": "^4.7.7",
             "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.2.1",
-            "meow": "^4.0.0",
-            "semver": "^5.5.0",
+            "lodash": "^4.17.15",
+            "meow": "^8.0.0",
+            "semver": "^6.0.0",
             "split": "^1.0.0",
-            "through2": "^2.0.0"
+            "through2": "^4.0.0"
          },
          "dependencies": {
             "dateformat": {
@@ -2833,38 +2528,41 @@
                "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
                "dev": true
             },
-            "meow": {
-               "version": "4.0.1",
-               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+            "readable-stream": {
+               "version": "3.6.0",
+               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+               "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                "dev": true,
                "requires": {
-                  "camelcase-keys": "^4.0.0",
-                  "decamelize-keys": "^1.0.0",
-                  "loud-rejection": "^1.0.0",
-                  "minimist": "^1.1.3",
-                  "minimist-options": "^3.0.1",
-                  "normalize-package-data": "^2.3.4",
-                  "read-pkg-up": "^3.0.0",
-                  "redent": "^2.0.0",
-                  "trim-newlines": "^2.0.0"
+                  "inherits": "^2.0.3",
+                  "string_decoder": "^1.1.1",
+                  "util-deprecate": "^1.0.1"
+               }
+            },
+            "semver": {
+               "version": "6.3.0",
+               "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+               "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+               "dev": true
+            },
+            "through2": {
+               "version": "4.0.2",
+               "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+               "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+               "dev": true,
+               "requires": {
+                  "readable-stream": "3"
                }
             }
          }
       },
-      "conventional-commit-types": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/conventional-commit-types/-/conventional-commit-types-3.0.0.tgz",
-         "integrity": "sha512-SmmCYnOniSsAa9GqWOeLqc179lfr5TRu5b4QFDkbsrJ5TZjPJx85wtOr3zn+1dbeNiXDKGPbZ72IKbPhLXh/Lg==",
-         "dev": true
-      },
       "conventional-commits-filter": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.1.tgz",
-         "integrity": "sha512-92OU8pz/977udhBjgPEbg3sbYzIxMDFTlQT97w7KdhR9igNqdJvy8smmedAAgn4tPiqseFloKkrVfbXCVd+E7A==",
+         "version": "2.0.7",
+         "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
+         "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
          "dev": true,
          "requires": {
-            "is-subset": "^0.1.1",
+            "lodash.ismatch": "^4.4.0",
             "modify-values": "^1.0.0"
          }
       },
@@ -2882,12 +2580,6 @@
             "through2": "^4.0.0"
          },
          "dependencies": {
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            },
             "readable-stream": {
                "version": "3.6.0",
                "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -2919,69 +2611,6 @@
             }
          }
       },
-      "conventional-recommended-bump": {
-         "version": "4.0.4",
-         "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
-         "integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
-         "dev": true,
-         "requires": {
-            "concat-stream": "^1.6.0",
-            "conventional-changelog-preset-loader": "^2.0.2",
-            "conventional-commits-filter": "^2.0.1",
-            "conventional-commits-parser": "^3.0.1",
-            "git-raw-commits": "2.0.0",
-            "git-semver-tags": "^2.0.2",
-            "meow": "^4.0.0",
-            "q": "^1.5.1"
-         },
-         "dependencies": {
-            "conventional-commits-parser": {
-               "version": "3.0.1",
-               "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.1.tgz",
-               "integrity": "sha512-P6U5UOvDeidUJ8ebHVDIoXzI7gMlQ1OF/id6oUvp8cnZvOXMt1n8nYl74Ey9YMn0uVQtxmCtjPQawpsssBWtGg==",
-               "dev": true,
-               "requires": {
-                  "JSONStream": "^1.0.4",
-                  "is-text-path": "^1.0.0",
-                  "lodash": "^4.2.1",
-                  "meow": "^4.0.0",
-                  "split2": "^2.0.0",
-                  "through2": "^2.0.0",
-                  "trim-off-newlines": "^1.0.0"
-               }
-            },
-            "git-raw-commits": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-               "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
-               "dev": true,
-               "requires": {
-                  "dargs": "^4.0.1",
-                  "lodash.template": "^4.0.2",
-                  "meow": "^4.0.0",
-                  "split2": "^2.0.0",
-                  "through2": "^2.0.0"
-               }
-            },
-            "meow": {
-               "version": "4.0.1",
-               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-               "dev": true,
-               "requires": {
-                  "camelcase-keys": "^4.0.0",
-                  "decamelize-keys": "^1.0.0",
-                  "loud-rejection": "^1.0.0",
-                  "minimist": "^1.1.3",
-                  "minimist-options": "^3.0.1",
-                  "normalize-package-data": "^2.3.4",
-                  "read-pkg-up": "^3.0.0",
-                  "redent": "^2.0.0",
-                  "trim-newlines": "^2.0.0"
-               }
-            }
-         }
-      },
       "convert-source-map": {
          "version": "1.8.0",
          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -2997,51 +2626,11 @@
          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
          "dev": true
       },
-      "core-js": {
-         "version": "2.6.11",
-         "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-         "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
-         "dev": true,
-         "optional": true
-      },
       "core-util-is": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
          "dev": true
-      },
-      "cosmiconfig": {
-         "version": "5.2.1",
-         "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-         "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-         "dev": true,
-         "optional": true,
-         "requires": {
-            "import-fresh": "^2.0.0",
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.13.1",
-            "parse-json": "^4.0.0"
-         },
-         "dependencies": {
-            "import-fresh": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-               "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-               "dev": true,
-               "optional": true,
-               "requires": {
-                  "caller-path": "^2.0.0",
-                  "resolve-from": "^3.0.0"
-               }
-            },
-            "resolve-from": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-               "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-               "dev": true,
-               "optional": true
-            }
-         }
       },
       "coveralls": {
          "version": "3.0.9",
@@ -3082,44 +2671,6 @@
          "dev": true,
          "requires": {
             "array-find-index": "^1.0.1"
-         }
-      },
-      "cz-conventional-changelog": {
-         "version": "3.1.0",
-         "resolved": "https://registry.npmjs.org/cz-conventional-changelog/-/cz-conventional-changelog-3.1.0.tgz",
-         "integrity": "sha512-SCwPPOF+7qMh1DZkJhrwaxCvZzPaz2E9BwQzcZwBuHlpcJj9zzz7K5vADQRhHuxStaHZFSLbDlZEdcls4bKu7Q==",
-         "dev": true,
-         "requires": {
-            "@commitlint/load": ">6.1.1",
-            "chalk": "^2.4.1",
-            "commitizen": "^4.0.3",
-            "conventional-commit-types": "^3.0.0",
-            "lodash.map": "^4.5.1",
-            "longest": "^2.0.1",
-            "right-pad": "^1.0.1",
-            "word-wrap": "^1.0.3"
-         },
-         "dependencies": {
-            "chalk": {
-               "version": "2.4.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^3.2.1",
-                  "escape-string-regexp": "^1.0.5",
-                  "supports-color": "^5.3.0"
-               }
-            }
-         }
-      },
-      "dargs": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.1.0.tgz",
-         "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
-         "dev": true,
-         "requires": {
-            "number-is-nan": "^1.0.0"
          }
       },
       "dashdash": {
@@ -3358,12 +2909,6 @@
          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
          "dev": true
       },
-      "dedent": {
-         "version": "0.7.0",
-         "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-         "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-         "dev": true
-      },
       "deep-eql": {
          "version": "3.0.1",
          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -3436,18 +2981,6 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
          "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
-         "dev": true
-      },
-      "detect-indent": {
-         "version": "5.0.0",
-         "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-         "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
-         "dev": true
-      },
-      "detect-newline": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
-         "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
          "dev": true
       },
       "diff": {
@@ -3526,67 +3059,12 @@
          }
       },
       "dot-prop": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-         "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+         "version": "5.3.0",
+         "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+         "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
          "dev": true,
          "requires": {
-            "is-obj": "^1.0.0"
-         }
-      },
-      "dotgitignore": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/dotgitignore/-/dotgitignore-2.1.0.tgz",
-         "integrity": "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA==",
-         "dev": true,
-         "requires": {
-            "find-up": "^3.0.0",
-            "minimatch": "^3.0.4"
-         },
-         "dependencies": {
-            "find-up": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-               "dev": true,
-               "requires": {
-                  "locate-path": "^3.0.0"
-               }
-            },
-            "locate-path": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-               "dev": true,
-               "requires": {
-                  "p-locate": "^3.0.0",
-                  "path-exists": "^3.0.0"
-               }
-            },
-            "p-limit": {
-               "version": "2.2.0",
-               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-               "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-               "dev": true,
-               "requires": {
-                  "p-try": "^2.0.0"
-               }
-            },
-            "p-locate": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-               "dev": true,
-               "requires": {
-                  "p-limit": "^2.0.0"
-               }
-            },
-            "p-try": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-               "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
-               "dev": true
-            }
+            "is-obj": "^2.0.0"
          }
       },
       "duplexify": {
@@ -3633,9 +3111,9 @@
          }
       },
       "entities": {
-         "version": "2.0.3",
-         "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
-         "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+         "version": "2.1.0",
+         "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+         "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
          "dev": true
       },
       "error": {
@@ -3846,12 +3324,6 @@
                "version": "3.0.0",
                "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-               "dev": true
-            },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
                "dev": true
             },
             "mimic-fn": {
@@ -4461,15 +3933,6 @@
             "websocket-driver": ">=0.5.1"
          }
       },
-      "figures": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-         "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-         "dev": true,
-         "requires": {
-            "escape-string-regexp": "^1.0.5"
-         }
-      },
       "file-entry-cache": {
          "version": "5.0.1",
          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
@@ -4502,22 +3965,6 @@
             }
          }
       },
-      "find-node-modules": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/find-node-modules/-/find-node-modules-2.0.0.tgz",
-         "integrity": "sha512-8MWIBRgJi/WpjjfVXumjPKCtmQ10B+fjx6zmSA+770GMJirLhWIzg8l763rhjl9xaeaHbnxPNRQKq2mgMhr+aw==",
-         "dev": true,
-         "requires": {
-            "findup-sync": "^3.0.0",
-            "merge": "^1.2.1"
-         }
-      },
-      "find-root": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-         "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
-         "dev": true
-      },
       "find-up": {
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -4525,18 +3972,6 @@
          "dev": true,
          "requires": {
             "locate-path": "^2.0.0"
-         }
-      },
-      "findup-sync": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
-         "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
-         "dev": true,
-         "requires": {
-            "detect-file": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "micromatch": "^3.0.4",
-            "resolve-dir": "^1.0.1"
          }
       },
       "fined": {
@@ -4616,34 +4051,6 @@
             "map-cache": "^0.2.2"
          }
       },
-      "fs-access": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-         "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
-         "dev": true,
-         "requires": {
-            "null-check": "^1.0.0"
-         }
-      },
-      "fs-extra": {
-         "version": "8.1.0",
-         "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-         "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-         "dev": true,
-         "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-         },
-         "dependencies": {
-            "graceful-fs": {
-               "version": "4.2.3",
-               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-               "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-               "dev": true
-            }
-         }
-      },
       "fs.realpath": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4677,12 +4084,6 @@
          "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
          "dev": true
       },
-      "get-caller-file": {
-         "version": "1.0.3",
-         "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-         "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-         "dev": true
-      },
       "get-func-name": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -4690,185 +4091,130 @@
          "dev": true
       },
       "get-pkg-repo": {
-         "version": "1.4.0",
-         "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",
-         "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
+         "version": "4.2.1",
+         "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-4.2.1.tgz",
+         "integrity": "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA==",
          "dev": true,
          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "meow": "^3.3.0",
-            "normalize-package-data": "^2.3.0",
-            "parse-github-repo-url": "^1.3.0",
-            "through2": "^2.0.0"
+            "@hutson/parse-repository-url": "^3.0.0",
+            "hosted-git-info": "^4.0.0",
+            "through2": "^2.0.0",
+            "yargs": "^16.2.0"
          },
          "dependencies": {
-            "camelcase": {
-               "version": "2.1.1",
-               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-               "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "ansi-regex": {
+               "version": "5.0.1",
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+               "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                "dev": true
             },
-            "camelcase-keys": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-               "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "ansi-styles": {
+               "version": "4.3.0",
+               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                "dev": true,
                "requires": {
-                  "camelcase": "^2.0.0",
-                  "map-obj": "^1.0.0"
+                  "color-convert": "^2.0.1"
                }
             },
-            "find-up": {
-               "version": "1.1.2",
-               "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "cliui": {
+               "version": "7.0.4",
+               "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+               "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
                "dev": true,
                "requires": {
-                  "path-exists": "^2.0.0",
-                  "pinkie-promise": "^2.0.0"
+                  "string-width": "^4.2.0",
+                  "strip-ansi": "^6.0.0",
+                  "wrap-ansi": "^7.0.0"
                }
             },
-            "get-stdin": {
-               "version": "4.0.1",
-               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-               "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "color-convert": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+               "dev": true,
+               "requires": {
+                  "color-name": "~1.1.4"
+               }
+            },
+            "color-name": {
+               "version": "1.1.4",
+               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                "dev": true
             },
-            "indent-string": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-               "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-               "dev": true,
-               "requires": {
-                  "repeating": "^2.0.0"
-               }
-            },
-            "load-json-file": {
-               "version": "1.1.0",
-               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-               "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-               "dev": true,
-               "requires": {
-                  "graceful-fs": "^4.1.2",
-                  "parse-json": "^2.2.0",
-                  "pify": "^2.0.0",
-                  "pinkie-promise": "^2.0.0",
-                  "strip-bom": "^2.0.0"
-               }
-            },
-            "map-obj": {
-               "version": "1.0.1",
-               "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-               "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "get-caller-file": {
+               "version": "2.0.5",
+               "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+               "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
                "dev": true
             },
-            "meow": {
-               "version": "3.7.0",
-               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-               "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "hosted-git-info": {
+               "version": "4.1.0",
+               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+               "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
                "dev": true,
                "requires": {
-                  "camelcase-keys": "^2.0.0",
-                  "decamelize": "^1.1.2",
-                  "loud-rejection": "^1.0.0",
-                  "map-obj": "^1.0.1",
-                  "minimist": "^1.1.3",
-                  "normalize-package-data": "^2.3.4",
-                  "object-assign": "^4.0.1",
-                  "read-pkg-up": "^1.0.1",
-                  "redent": "^1.0.0",
-                  "trim-newlines": "^1.0.0"
+                  "lru-cache": "^6.0.0"
                }
             },
-            "parse-json": {
-               "version": "2.2.0",
-               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-               "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-               "dev": true,
-               "requires": {
-                  "error-ex": "^1.2.0"
-               }
-            },
-            "path-exists": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-               "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-               "dev": true,
-               "requires": {
-                  "pinkie-promise": "^2.0.0"
-               }
-            },
-            "path-type": {
-               "version": "1.1.0",
-               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-               "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-               "dev": true,
-               "requires": {
-                  "graceful-fs": "^4.1.2",
-                  "pify": "^2.0.0",
-                  "pinkie-promise": "^2.0.0"
-               }
-            },
-            "pify": {
-               "version": "2.3.0",
-               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "is-fullwidth-code-point": {
+               "version": "3.0.0",
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+               "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
                "dev": true
             },
-            "read-pkg": {
-               "version": "1.1.0",
-               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-               "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "string-width": {
+               "version": "4.2.3",
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+               "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
                "dev": true,
                "requires": {
-                  "load-json-file": "^1.0.0",
-                  "normalize-package-data": "^2.3.2",
-                  "path-type": "^1.0.0"
+                  "emoji-regex": "^8.0.0",
+                  "is-fullwidth-code-point": "^3.0.0",
+                  "strip-ansi": "^6.0.1"
                }
             },
-            "read-pkg-up": {
-               "version": "1.0.1",
-               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-               "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "strip-ansi": {
+               "version": "6.0.1",
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+               "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
                "dev": true,
                "requires": {
-                  "find-up": "^1.0.0",
-                  "read-pkg": "^1.0.0"
+                  "ansi-regex": "^5.0.1"
                }
             },
-            "redent": {
-               "version": "1.0.0",
-               "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-               "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "wrap-ansi": {
+               "version": "7.0.0",
+               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+               "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
                "dev": true,
                "requires": {
-                  "indent-string": "^2.1.0",
-                  "strip-indent": "^1.0.1"
+                  "ansi-styles": "^4.0.0",
+                  "string-width": "^4.1.0",
+                  "strip-ansi": "^6.0.0"
                }
             },
-            "strip-bom": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-               "dev": true,
-               "requires": {
-                  "is-utf8": "^0.2.0"
-               }
-            },
-            "strip-indent": {
-               "version": "1.0.1",
-               "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-               "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-               "dev": true,
-               "requires": {
-                  "get-stdin": "^4.0.1"
-               }
-            },
-            "trim-newlines": {
-               "version": "1.0.0",
-               "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-               "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "y18n": {
+               "version": "5.0.8",
+               "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+               "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
                "dev": true
+            },
+            "yargs": {
+               "version": "16.2.0",
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+               "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+               "dev": true,
+               "requires": {
+                  "cliui": "^7.0.2",
+                  "escalade": "^3.1.1",
+                  "get-caller-file": "^2.0.5",
+                  "require-directory": "^2.1.1",
+                  "string-width": "^4.2.0",
+                  "y18n": "^5.0.5",
+                  "yargs-parser": "^20.2.2"
+               }
             }
          }
       },
@@ -4924,12 +4270,6 @@
                "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
                "dev": true
             },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            },
             "readable-stream": {
                "version": "3.6.0",
                "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -4976,35 +4316,6 @@
                "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                "dev": true
-            }
-         }
-      },
-      "git-semver-tags": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
-         "integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
-         "dev": true,
-         "requires": {
-            "meow": "^4.0.0",
-            "semver": "^5.5.0"
-         },
-         "dependencies": {
-            "meow": {
-               "version": "4.0.1",
-               "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-               "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-               "dev": true,
-               "requires": {
-                  "camelcase-keys": "^4.0.0",
-                  "decamelize-keys": "^1.0.0",
-                  "loud-rejection": "^1.0.0",
-                  "minimist": "^1.1.3",
-                  "minimist-options": "^3.0.1",
-                  "normalize-package-data": "^2.3.4",
-                  "read-pkg-up": "^3.0.0",
-                  "redent": "^2.0.0",
-                  "trim-newlines": "^2.0.0"
-               }
             }
          }
       },
@@ -5328,369 +4639,6 @@
             }
          }
       },
-      "grunt-eslint": {
-         "version": "24.0.0",
-         "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.0.tgz",
-         "integrity": "sha512-WpTeBBFweyhMuPjGwRSQV9JFJ+EczIdlsc7Dd/1g78QVI1aZsk4g/H3e+3S5HEwsS1RKL2YZIrGj8hMLlBfN8w==",
-         "dev": true,
-         "requires": {
-            "chalk": "^4.1.2",
-            "eslint": "^8.0.1"
-         },
-         "dependencies": {
-            "acorn": {
-               "version": "8.7.0",
-               "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-               "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-               "dev": true
-            },
-            "ansi-regex": {
-               "version": "5.0.1",
-               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-               "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-               "dev": true
-            },
-            "ansi-styles": {
-               "version": "4.3.0",
-               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-               "dev": true,
-               "requires": {
-                  "color-convert": "^2.0.1"
-               }
-            },
-            "argparse": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-               "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-               "dev": true
-            },
-            "chalk": {
-               "version": "4.1.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-               "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^4.1.0",
-                  "supports-color": "^7.1.0"
-               }
-            },
-            "color-convert": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-               "dev": true,
-               "requires": {
-                  "color-name": "~1.1.4"
-               }
-            },
-            "color-name": {
-               "version": "1.1.4",
-               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-               "dev": true
-            },
-            "cross-spawn": {
-               "version": "7.0.3",
-               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-               "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-               "dev": true,
-               "requires": {
-                  "path-key": "^3.1.0",
-                  "shebang-command": "^2.0.0",
-                  "which": "^2.0.1"
-               }
-            },
-            "escape-string-regexp": {
-               "version": "4.0.0",
-               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-               "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-               "dev": true
-            },
-            "eslint": {
-               "version": "8.8.0",
-               "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
-               "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
-               "dev": true,
-               "requires": {
-                  "@eslint/eslintrc": "^1.0.5",
-                  "@humanwhocodes/config-array": "^0.9.2",
-                  "ajv": "^6.10.0",
-                  "chalk": "^4.0.0",
-                  "cross-spawn": "^7.0.2",
-                  "debug": "^4.3.2",
-                  "doctrine": "^3.0.0",
-                  "escape-string-regexp": "^4.0.0",
-                  "eslint-scope": "^7.1.0",
-                  "eslint-utils": "^3.0.0",
-                  "eslint-visitor-keys": "^3.2.0",
-                  "espree": "^9.3.0",
-                  "esquery": "^1.4.0",
-                  "esutils": "^2.0.2",
-                  "fast-deep-equal": "^3.1.3",
-                  "file-entry-cache": "^6.0.1",
-                  "functional-red-black-tree": "^1.0.1",
-                  "glob-parent": "^6.0.1",
-                  "globals": "^13.6.0",
-                  "ignore": "^5.2.0",
-                  "import-fresh": "^3.0.0",
-                  "imurmurhash": "^0.1.4",
-                  "is-glob": "^4.0.0",
-                  "js-yaml": "^4.1.0",
-                  "json-stable-stringify-without-jsonify": "^1.0.1",
-                  "levn": "^0.4.1",
-                  "lodash.merge": "^4.6.2",
-                  "minimatch": "^3.0.4",
-                  "natural-compare": "^1.4.0",
-                  "optionator": "^0.9.1",
-                  "regexpp": "^3.2.0",
-                  "strip-ansi": "^6.0.1",
-                  "strip-json-comments": "^3.1.0",
-                  "text-table": "^0.2.0",
-                  "v8-compile-cache": "^2.0.3"
-               }
-            },
-            "eslint-scope": {
-               "version": "7.1.0",
-               "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
-               "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
-               "dev": true,
-               "requires": {
-                  "esrecurse": "^4.3.0",
-                  "estraverse": "^5.2.0"
-               }
-            },
-            "eslint-utils": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-               "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-               "dev": true,
-               "requires": {
-                  "eslint-visitor-keys": "^2.0.0"
-               },
-               "dependencies": {
-                  "eslint-visitor-keys": {
-                     "version": "2.1.0",
-                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                     "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                     "dev": true
-                  }
-               }
-            },
-            "eslint-visitor-keys": {
-               "version": "3.2.0",
-               "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
-               "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
-               "dev": true
-            },
-            "espree": {
-               "version": "9.3.0",
-               "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
-               "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
-               "dev": true,
-               "requires": {
-                  "acorn": "^8.7.0",
-                  "acorn-jsx": "^5.3.1",
-                  "eslint-visitor-keys": "^3.1.0"
-               }
-            },
-            "estraverse": {
-               "version": "5.3.0",
-               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-               "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-               "dev": true
-            },
-            "fast-deep-equal": {
-               "version": "3.1.3",
-               "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-               "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-               "dev": true
-            },
-            "file-entry-cache": {
-               "version": "6.0.1",
-               "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-               "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-               "dev": true,
-               "requires": {
-                  "flat-cache": "^3.0.4"
-               }
-            },
-            "flat-cache": {
-               "version": "3.0.4",
-               "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-               "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-               "dev": true,
-               "requires": {
-                  "flatted": "^3.1.0",
-                  "rimraf": "^3.0.2"
-               }
-            },
-            "flatted": {
-               "version": "3.2.5",
-               "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-               "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
-               "dev": true
-            },
-            "glob-parent": {
-               "version": "6.0.2",
-               "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-               "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-               "dev": true,
-               "requires": {
-                  "is-glob": "^4.0.3"
-               },
-               "dependencies": {
-                  "is-glob": {
-                     "version": "4.0.3",
-                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-                     "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-                     "dev": true,
-                     "requires": {
-                        "is-extglob": "^2.1.1"
-                     }
-                  }
-               }
-            },
-            "globals": {
-               "version": "13.12.1",
-               "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
-               "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
-               "dev": true,
-               "requires": {
-                  "type-fest": "^0.20.2"
-               }
-            },
-            "has-flag": {
-               "version": "4.0.0",
-               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-               "dev": true
-            },
-            "ignore": {
-               "version": "5.2.0",
-               "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-               "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-               "dev": true
-            },
-            "js-yaml": {
-               "version": "4.1.0",
-               "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-               "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-               "dev": true,
-               "requires": {
-                  "argparse": "^2.0.1"
-               }
-            },
-            "levn": {
-               "version": "0.4.1",
-               "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-               "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-               "dev": true,
-               "requires": {
-                  "prelude-ls": "^1.2.1",
-                  "type-check": "~0.4.0"
-               }
-            },
-            "optionator": {
-               "version": "0.9.1",
-               "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
-               "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
-               "dev": true,
-               "requires": {
-                  "deep-is": "^0.1.3",
-                  "fast-levenshtein": "^2.0.6",
-                  "levn": "^0.4.1",
-                  "prelude-ls": "^1.2.1",
-                  "type-check": "^0.4.0",
-                  "word-wrap": "^1.2.3"
-               }
-            },
-            "path-key": {
-               "version": "3.1.1",
-               "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-               "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-               "dev": true
-            },
-            "prelude-ls": {
-               "version": "1.2.1",
-               "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-               "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-               "dev": true
-            },
-            "rimraf": {
-               "version": "3.0.2",
-               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-               "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-               "dev": true,
-               "requires": {
-                  "glob": "^7.1.3"
-               }
-            },
-            "shebang-command": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-               "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-               "dev": true,
-               "requires": {
-                  "shebang-regex": "^3.0.0"
-               }
-            },
-            "shebang-regex": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-               "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-               "dev": true
-            },
-            "strip-ansi": {
-               "version": "6.0.1",
-               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-               "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-               "dev": true,
-               "requires": {
-                  "ansi-regex": "^5.0.1"
-               }
-            },
-            "strip-json-comments": {
-               "version": "3.1.1",
-               "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-               "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-               "dev": true
-            },
-            "supports-color": {
-               "version": "7.2.0",
-               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-               "dev": true,
-               "requires": {
-                  "has-flag": "^4.0.0"
-               }
-            },
-            "type-check": {
-               "version": "0.4.0",
-               "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-               "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-               "dev": true,
-               "requires": {
-                  "prelude-ls": "^1.2.1"
-               }
-            },
-            "type-fest": {
-               "version": "0.20.2",
-               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-               "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-               "dev": true
-            },
-            "which": {
-               "version": "2.0.2",
-               "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-               "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-               "dev": true,
-               "requires": {
-                  "isexe": "^2.0.0"
-               }
-            }
-         }
-      },
       "grunt-exec": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
@@ -5753,87 +4701,25 @@
             "which": "~1.3.0"
          }
       },
-      "grunt-markdownlint": {
-         "version": "2.9.0",
-         "resolved": "https://registry.npmjs.org/grunt-markdownlint/-/grunt-markdownlint-2.9.0.tgz",
-         "integrity": "sha512-jLzTzNVZN/u2iblV2j+2xfJGG+Mv8NMl5CAOWNQftV7SOHnstwR/tiZPac8ZTmJFqwAqCwafIvu9wP2naAS8Og==",
-         "dev": true,
-         "requires": {
-            "markdownlint": "^0.19.0"
-         }
-      },
-      "grunt-stylelint": {
-         "version": "0.16.0",
-         "resolved": "https://registry.npmjs.org/grunt-stylelint/-/grunt-stylelint-0.16.0.tgz",
-         "integrity": "sha512-ullm0h9iCdgPEDq1TNwKL5HteXA4zke6wbYoRtsO32ATCU3zfUXmDN9unhu+joEcdgJKOPcd2+7UhRNXO1rr+w==",
-         "dev": true,
-         "requires": {
-            "chalk": "^4.1.0"
-         },
-         "dependencies": {
-            "ansi-styles": {
-               "version": "4.3.0",
-               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-               "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-               "dev": true,
-               "requires": {
-                  "color-convert": "^2.0.1"
-               }
-            },
-            "chalk": {
-               "version": "4.1.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-               "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^4.1.0",
-                  "supports-color": "^7.1.0"
-               }
-            },
-            "color-convert": {
-               "version": "2.0.1",
-               "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-               "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-               "dev": true,
-               "requires": {
-                  "color-name": "~1.1.4"
-               }
-            },
-            "color-name": {
-               "version": "1.1.4",
-               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-               "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-               "dev": true
-            },
-            "has-flag": {
-               "version": "4.0.0",
-               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-               "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-               "dev": true
-            },
-            "supports-color": {
-               "version": "7.2.0",
-               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-               "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-               "dev": true,
-               "requires": {
-                  "has-flag": "^4.0.0"
-               }
-            }
-         }
-      },
       "handlebars": {
-         "version": "4.1.1",
-         "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-         "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+         "version": "4.7.7",
+         "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+         "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
          "dev": true,
          "requires": {
+            "minimist": "^1.2.5",
             "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
             "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
+            "uglify-js": "^3.1.4",
+            "wordwrap": "^1.0.0"
          },
          "dependencies": {
+            "minimist": {
+               "version": "1.2.6",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+               "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+               "dev": true
+            },
             "source-map": {
                "version": "0.6.1",
                "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6045,12 +4931,6 @@
          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
          "dev": true
       },
-      "indent-string": {
-         "version": "3.2.0",
-         "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-         "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-         "dev": true
-      },
       "inflight": {
          "version": "1.0.6",
          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6071,73 +4951,6 @@
          "version": "1.3.5",
          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-         "dev": true
-      },
-      "inquirer": {
-         "version": "6.5.0",
-         "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
-         "integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
-         "dev": true,
-         "requires": {
-            "ansi-escapes": "^3.2.0",
-            "chalk": "^2.4.2",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^3.0.3",
-            "figures": "^2.0.0",
-            "lodash": "^4.17.12",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^6.4.0",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^5.1.0",
-            "through": "^2.3.6"
-         },
-         "dependencies": {
-            "ansi-regex": {
-               "version": "4.1.0",
-               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-               "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-               "dev": true
-            },
-            "chalk": {
-               "version": "2.4.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^3.2.1",
-                  "escape-string-regexp": "^1.0.5",
-                  "supports-color": "^5.3.0"
-               }
-            },
-            "lodash": {
-               "version": "4.17.15",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-               "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-               "dev": true
-            },
-            "strip-ansi": {
-               "version": "5.2.0",
-               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-               "dev": true,
-               "requires": {
-                  "ansi-regex": "^4.1.0"
-               }
-            }
-         }
-      },
-      "interpret": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-         "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-         "dev": true
-      },
-      "invert-kv": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-         "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
          "dev": true
       },
       "is-absolute": {
@@ -6252,13 +5065,6 @@
             }
          }
       },
-      "is-directory": {
-         "version": "0.3.1",
-         "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-         "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-         "dev": true,
-         "optional": true
-      },
       "is-extendable": {
          "version": "0.1.1",
          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6322,9 +5128,9 @@
          }
       },
       "is-obj": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-         "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+         "version": "2.0.0",
+         "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+         "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
          "dev": true
       },
       "is-plain-obj": {
@@ -6342,12 +5148,6 @@
             "isobject": "^3.0.1"
          }
       },
-      "is-promise": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-         "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-         "dev": true
-      },
       "is-regexp": {
          "version": "2.1.0",
          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
@@ -6362,18 +5162,6 @@
          "requires": {
             "is-unc-path": "^1.0.0"
          }
-      },
-      "is-stream": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-         "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-         "dev": true
-      },
-      "is-subset": {
-         "version": "0.1.1",
-         "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-         "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
-         "dev": true
       },
       "is-text-path": {
          "version": "1.0.1",
@@ -6549,15 +5337,6 @@
          "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
          "dev": true
       },
-      "jsonfile": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-         "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-         "dev": true,
-         "requires": {
-            "graceful-fs": "^4.1.6"
-         }
-      },
       "jsonparse": {
          "version": "1.3.1",
          "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -6593,15 +5372,6 @@
          "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
          "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
          "dev": true
-      },
-      "lcid": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-         "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-         "dev": true,
-         "requires": {
-            "invert-kv": "^2.0.0"
-         }
       },
       "lcov-parse": {
          "version": "1.0.0",
@@ -6665,9 +5435,9 @@
          "dev": true
       },
       "linkify-it": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-         "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+         "version": "3.0.3",
+         "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+         "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
          "dev": true,
          "requires": {
             "uc.micro": "^1.0.1"
@@ -6702,15 +5472,9 @@
          }
       },
       "lodash": {
-         "version": "4.17.11",
-         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-         "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-         "dev": true
-      },
-      "lodash._reinterpolate": {
-         "version": "3.0.0",
-         "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-         "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+         "version": "4.17.21",
+         "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+         "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
          "dev": true
       },
       "lodash.assign": {
@@ -6719,54 +5483,17 @@
          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
          "dev": true
       },
-      "lodash.differencewith": {
-         "version": "4.5.0",
-         "resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
-         "integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
-         "dev": true
-      },
-      "lodash.flatten": {
-         "version": "4.4.0",
-         "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-         "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-         "dev": true
-      },
       "lodash.get": {
          "version": "4.4.2",
          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
          "dev": true
       },
-      "lodash.map": {
-         "version": "4.6.0",
-         "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-         "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-         "dev": true
-      },
-      "lodash.merge": {
-         "version": "4.6.2",
-         "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-         "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-         "dev": true
-      },
-      "lodash.template": {
+      "lodash.ismatch": {
          "version": "4.4.0",
-         "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-         "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
-         "dev": true,
-         "requires": {
-            "lodash._reinterpolate": "~3.0.0",
-            "lodash.templatesettings": "^4.0.0"
-         }
-      },
-      "lodash.templatesettings": {
-         "version": "4.1.0",
-         "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-         "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
-         "dev": true,
-         "requires": {
-            "lodash._reinterpolate": "~3.0.0"
-         }
+         "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+         "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+         "dev": true
       },
       "lodash.truncate": {
          "version": "4.4.2",
@@ -6847,12 +5574,6 @@
          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
          "dev": true
       },
-      "longest": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
-         "integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
-         "dev": true
-      },
       "longest-streak": {
          "version": "2.0.4",
          "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
@@ -6893,25 +5614,10 @@
             "kind-of": "^6.0.2"
          }
       },
-      "map-age-cleaner": {
-         "version": "0.1.3",
-         "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-         "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-         "dev": true,
-         "requires": {
-            "p-defer": "^1.0.0"
-         }
-      },
       "map-cache": {
          "version": "0.2.2",
          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-         "dev": true
-      },
-      "map-obj": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-         "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
          "dev": true
       },
       "map-values": {
@@ -6930,46 +5636,50 @@
          }
       },
       "markdown-it": {
-         "version": "10.0.0",
-         "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
-         "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+         "version": "12.3.2",
+         "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+         "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
          "dev": true,
          "requires": {
-            "argparse": "^1.0.7",
-            "entities": "~2.0.0",
-            "linkify-it": "^2.0.0",
+            "argparse": "^2.0.1",
+            "entities": "~2.1.0",
+            "linkify-it": "^3.0.1",
             "mdurl": "^1.0.1",
             "uc.micro": "^1.0.5"
+         },
+         "dependencies": {
+            "argparse": {
+               "version": "2.0.1",
+               "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+               "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+               "dev": true
+            }
          }
       },
       "markdownlint": {
-         "version": "0.19.0",
-         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.19.0.tgz",
-         "integrity": "sha512-+MsWOnYVUH4klcKM7iRx5cno9FQMDAb6FC6mWlZkeXPwIaK6Z5Vd9VkXkykPidRqmLHU2wI+MNyfUMnUCBw3pQ==",
+         "version": "0.25.1",
+         "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+         "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
          "dev": true,
          "requires": {
-            "markdown-it": "10.0.0"
+            "markdown-it": "12.3.2"
          }
       },
       "markdownlint-cli": {
-         "version": "0.28.1",
-         "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.28.1.tgz",
-         "integrity": "sha512-RBKtRRBzcuAF/H5wMSzb4zvEtbUkyYNEeaDtlQkyH9SoHWPL01emJ2Wrx6NEOa1ZDGwB+seBGvE157Qzc/t/vA==",
+         "version": "0.31.1",
+         "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+         "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
          "dev": true,
          "requires": {
-            "commander": "~8.0.0",
-            "deep-extend": "~0.6.0",
-            "get-stdin": "~8.0.0",
-            "glob": "~7.1.7",
-            "ignore": "~5.1.8",
+            "commander": "~9.0.0",
+            "get-stdin": "~9.0.0",
+            "glob": "~7.2.0",
+            "ignore": "~5.2.0",
             "js-yaml": "^4.1.0",
             "jsonc-parser": "~3.0.0",
-            "lodash.differencewith": "~4.5.0",
-            "lodash.flatten": "~4.4.0",
-            "markdownlint": "~0.23.1",
-            "markdownlint-rule-helpers": "~0.14.0",
-            "minimatch": "~3.0.4",
-            "minimist": "~1.2.5",
+            "markdownlint": "~0.25.1",
+            "markdownlint-rule-helpers": "~0.16.0",
+            "minimatch": "~3.0.5",
             "run-con": "~1.2.10"
          },
          "dependencies": {
@@ -6980,35 +5690,46 @@
                "dev": true
             },
             "commander": {
-               "version": "8.0.0",
-               "resolved": "https://registry.npmjs.org/commander/-/commander-8.0.0.tgz",
-               "integrity": "sha512-Xvf85aAtu6v22+E5hfVoLHqyul/jyxh91zvqk/ioJTQuJR7Z78n7H558vMPKanPSRgIEeZemT92I2g9Y8LPbSQ==",
+               "version": "9.0.0",
+               "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+               "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
                "dev": true
             },
-            "entities": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-               "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "get-stdin": {
+               "version": "9.0.0",
+               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+               "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
                "dev": true
             },
             "glob": {
-               "version": "7.1.7",
-               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-               "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+               "version": "7.2.3",
+               "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+               "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
                "dev": true,
                "requires": {
                   "fs.realpath": "^1.0.0",
                   "inflight": "^1.0.4",
                   "inherits": "2",
-                  "minimatch": "^3.0.4",
+                  "minimatch": "^3.1.1",
                   "once": "^1.3.0",
                   "path-is-absolute": "^1.0.0"
+               },
+               "dependencies": {
+                  "minimatch": {
+                     "version": "3.1.2",
+                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                     "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                     "dev": true,
+                     "requires": {
+                        "brace-expansion": "^1.1.7"
+                     }
+                  }
                }
             },
             "ignore": {
-               "version": "5.1.9",
-               "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-               "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+               "version": "5.2.0",
+               "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+               "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
                "dev": true
             },
             "js-yaml": {
@@ -7020,49 +5741,21 @@
                   "argparse": "^2.0.1"
                }
             },
-            "linkify-it": {
-               "version": "3.0.3",
-               "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-               "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+            "minimatch": {
+               "version": "3.0.8",
+               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+               "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
                "dev": true,
                "requires": {
-                  "uc.micro": "^1.0.1"
+                  "brace-expansion": "^1.1.7"
                }
-            },
-            "markdown-it": {
-               "version": "12.0.4",
-               "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-               "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-               "dev": true,
-               "requires": {
-                  "argparse": "^2.0.1",
-                  "entities": "~2.1.0",
-                  "linkify-it": "^3.0.1",
-                  "mdurl": "^1.0.1",
-                  "uc.micro": "^1.0.5"
-               }
-            },
-            "markdownlint": {
-               "version": "0.23.1",
-               "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-               "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
-               "dev": true,
-               "requires": {
-                  "markdown-it": "12.0.4"
-               }
-            },
-            "minimist": {
-               "version": "1.2.5",
-               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-               "dev": true
             }
          }
       },
       "markdownlint-rule-helpers": {
-         "version": "0.14.0",
-         "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.14.0.tgz",
-         "integrity": "sha512-vRTPqSU4JK8vVXmjICHSBhwXUvbfh/VJo+j7hvxqe15tLJyomv3FLgFdFgb8kpj0Fe8SsJa/TZUAXv7/sN+N7A==",
+         "version": "0.16.0",
+         "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+         "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
          "dev": true
       },
       "mathml-tag-names": {
@@ -7109,25 +5802,6 @@
          "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
          "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
          "dev": true
-      },
-      "mem": {
-         "version": "4.2.0",
-         "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-         "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
-         "dev": true,
-         "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^2.0.0",
-            "p-is-promise": "^2.0.0"
-         },
-         "dependencies": {
-            "mimic-fn": {
-               "version": "2.0.0",
-               "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-               "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
-               "dev": true
-            }
-         }
       },
       "meow": {
          "version": "8.1.2",
@@ -7381,12 +6055,6 @@
             }
          }
       },
-      "merge": {
-         "version": "1.2.1",
-         "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-         "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-         "dev": true
-      },
       "merge-stream": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7445,12 +6113,6 @@
             "mime-db": "1.43.0"
          }
       },
-      "mimic-fn": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-         "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-         "dev": true
-      },
       "min-indent": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7471,16 +6133,6 @@
          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
          "dev": true
-      },
-      "minimist-options": {
-         "version": "3.0.2",
-         "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-         "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-         "dev": true,
-         "requires": {
-            "arrify": "^1.0.1",
-            "is-plain-obj": "^1.1.0"
-         }
       },
       "mixin-deep": {
          "version": "1.3.2",
@@ -7585,12 +6237,6 @@
          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
          "dev": true
       },
-      "mute-stream": {
-         "version": "0.0.7",
-         "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-         "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-         "dev": true
-      },
       "nanomatch": {
          "version": "1.2.13",
          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -7617,9 +6263,9 @@
          "dev": true
       },
       "neo-async": {
-         "version": "2.6.0",
-         "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-         "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+         "version": "2.6.2",
+         "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+         "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
          "dev": true
       },
       "nice-try": {
@@ -7692,21 +6338,6 @@
          "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
          "dev": true
       },
-      "npm-run-path": {
-         "version": "2.0.2",
-         "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-         "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-         "dev": true,
-         "requires": {
-            "path-key": "^2.0.0"
-         }
-      },
-      "null-check": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
-         "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
-         "dev": true
-      },
       "num2fraction": {
          "version": "1.2.2",
          "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -7754,7 +6385,8 @@
          "dependencies": {
             "align-text": {
                "version": "0.1.4",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+               "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -7765,17 +6397,20 @@
             },
             "amdefine": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+               "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
                "dev": true
             },
             "ansi-regex": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                "dev": true
             },
             "append-transform": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+               "integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
                "dev": true,
                "requires": {
                   "default-require-extensions": "^2.0.0"
@@ -7783,27 +6418,32 @@
             },
             "archy": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+               "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
                "dev": true
             },
             "arrify": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+               "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
                "dev": true
             },
             "async": {
                "version": "1.5.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+               "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
                "dev": true
             },
             "balanced-match": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                "dev": true
             },
             "brace-expansion": {
                "version": "1.1.11",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
                "dev": true,
                "requires": {
                   "balanced-match": "^1.0.0",
@@ -7812,12 +6452,14 @@
             },
             "builtin-modules": {
                "version": "1.1.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+               "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
                "dev": true
             },
             "caching-transform": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-2.0.0.tgz",
+               "integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
                "dev": true,
                "requires": {
                   "make-dir": "^1.0.0",
@@ -7828,13 +6470,15 @@
             },
             "camelcase": {
                "version": "1.2.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+               "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                "dev": true,
                "optional": true
             },
             "center-align": {
                "version": "0.1.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+               "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -7844,7 +6488,8 @@
             },
             "cliui": {
                "version": "2.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+               "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -7855,7 +6500,8 @@
                "dependencies": {
                   "wordwrap": {
                      "version": "0.0.2",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                     "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                      "dev": true,
                      "optional": true
                   }
@@ -7863,22 +6509,26 @@
             },
             "code-point-at": {
                "version": "1.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
                "dev": true
             },
             "commondir": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+               "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
                "dev": true
             },
             "concat-map": {
                "version": "0.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                "dev": true
             },
             "convert-source-map": {
                "version": "1.6.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+               "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
                "dev": true,
                "requires": {
                   "safe-buffer": "~5.1.1"
@@ -7886,7 +6536,8 @@
             },
             "cross-spawn": {
                "version": "4.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+               "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
                "dev": true,
                "requires": {
                   "lru-cache": "^4.0.1",
@@ -7895,7 +6546,8 @@
             },
             "debug": {
                "version": "3.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                "dev": true,
                "requires": {
                   "ms": "2.0.0"
@@ -7903,17 +6555,20 @@
             },
             "debug-log": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+               "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
                "dev": true
             },
             "decamelize": {
                "version": "1.2.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+               "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                "dev": true
             },
             "default-require-extensions": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+               "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
                "dev": true,
                "requires": {
                   "strip-bom": "^3.0.0"
@@ -7921,7 +6576,8 @@
             },
             "error-ex": {
                "version": "1.3.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+               "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
                "dev": true,
                "requires": {
                   "is-arrayish": "^0.2.1"
@@ -7929,12 +6585,14 @@
             },
             "es6-error": {
                "version": "4.1.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+               "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
                "dev": true
             },
             "execa": {
                "version": "0.7.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+               "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                "dev": true,
                "requires": {
                   "cross-spawn": "^5.0.1",
@@ -7948,7 +6606,8 @@
                "dependencies": {
                   "cross-spawn": {
                      "version": "5.1.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                      "dev": true,
                      "requires": {
                         "lru-cache": "^4.0.1",
@@ -7960,7 +6619,8 @@
             },
             "find-cache-dir": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
+               "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
                "dev": true,
                "requires": {
                   "commondir": "^1.0.1",
@@ -7970,7 +6630,8 @@
             },
             "find-up": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                "dev": true,
                "requires": {
                   "locate-path": "^3.0.0"
@@ -7978,7 +6639,8 @@
             },
             "foreground-child": {
                "version": "1.5.6",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+               "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
                "dev": true,
                "requires": {
                   "cross-spawn": "^4",
@@ -7987,22 +6649,26 @@
             },
             "fs.realpath": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+               "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
                "dev": true
             },
             "get-caller-file": {
                "version": "1.0.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+               "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
                "dev": true
             },
             "get-stream": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+               "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
                "dev": true
             },
             "glob": {
                "version": "7.1.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+               "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                "dev": true,
                "requires": {
                   "fs.realpath": "^1.0.0",
@@ -8015,12 +6681,14 @@
             },
             "graceful-fs": {
                "version": "4.1.11",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+               "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                "dev": true
             },
             "handlebars": {
                "version": "4.0.11",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+               "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
                "dev": true,
                "requires": {
                   "async": "^1.4.0",
@@ -8031,7 +6699,8 @@
                "dependencies": {
                   "source-map": {
                      "version": "0.4.4",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                      "dev": true,
                      "requires": {
                         "amdefine": ">=0.0.4"
@@ -8041,22 +6710,26 @@
             },
             "has-flag": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+               "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
                "dev": true
             },
             "hosted-git-info": {
                "version": "2.7.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+               "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
                "dev": true
             },
             "imurmurhash": {
                "version": "0.1.4",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+               "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
                "dev": true
             },
             "inflight": {
                "version": "1.0.6",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+               "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                "dev": true,
                "requires": {
                   "once": "^1.3.0",
@@ -8065,28 +6738,33 @@
             },
             "inherits": {
                "version": "2.0.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                "dev": true
             },
             "invert-kv": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+               "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                "dev": true
             },
             "is-arrayish": {
                "version": "0.2.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+               "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
                "dev": true
             },
             "is-buffer": {
                "version": "1.1.6",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+               "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
                "dev": true,
                "optional": true
             },
             "is-builtin-module": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+               "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
                "dev": true,
                "requires": {
                   "builtin-modules": "^1.0.0"
@@ -8094,27 +6772,32 @@
             },
             "is-fullwidth-code-point": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+               "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                "dev": true
             },
             "is-stream": {
                "version": "1.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+               "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
                "dev": true
             },
             "isexe": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+               "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
                "dev": true
             },
             "istanbul-lib-coverage": {
                "version": "2.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+               "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
                "dev": true
             },
             "istanbul-lib-hook": {
                "version": "2.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.1.tgz",
+               "integrity": "sha512-ufiZoiJ8CxY577JJWEeFuxXZoMqiKpq/RqZtOAYuQLvlkbJWscq9n3gc4xrCGH9n4pW0qnTxOz1oyMmVtk8E1w==",
                "dev": true,
                "requires": {
                   "append-transform": "^1.0.0"
@@ -8122,7 +6805,8 @@
             },
             "istanbul-lib-report": {
                "version": "2.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.2.tgz",
+               "integrity": "sha512-rJ8uR3peeIrwAxoDEbK4dJ7cqqtxBisZKCuwkMtMv0xYzaAnsAi3AHrHPAAtNXzG/bcCgZZ3OJVqm1DTi9ap2Q==",
                "dev": true,
                "requires": {
                   "istanbul-lib-coverage": "^2.0.1",
@@ -8132,7 +6816,8 @@
             },
             "istanbul-lib-source-maps": {
                "version": "2.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-2.0.1.tgz",
+               "integrity": "sha512-30l40ySg+gvBLcxTrLzR4Z2XTRj3HgRCA/p2rnbs/3OiTaoj054gAbuP5DcLOtwqmy4XW8qXBHzrmP2/bQ9i3A==",
                "dev": true,
                "requires": {
                   "debug": "^3.1.0",
@@ -8144,14 +6829,16 @@
                "dependencies": {
                   "source-map": {
                      "version": "0.6.1",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                      "dev": true
                   }
                }
             },
             "istanbul-reports": {
                "version": "2.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.0.1.tgz",
+               "integrity": "sha512-CT0QgMBJqs6NJLF678ZHcquUAZIoBIUNzdJrRJfpkI9OnzG6MkUfHxbJC3ln981dMswC7/B1mfX3LNkhgJxsuw==",
                "dev": true,
                "requires": {
                   "handlebars": "^4.0.11"
@@ -8159,12 +6846,14 @@
             },
             "json-parse-better-errors": {
                "version": "1.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+               "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
                "dev": true
             },
             "kind-of": {
                "version": "3.2.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -8173,13 +6862,15 @@
             },
             "lazy-cache": {
                "version": "1.0.4",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+               "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                "dev": true,
                "optional": true
             },
             "lcid": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+               "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
                "dev": true,
                "requires": {
                   "invert-kv": "^1.0.0"
@@ -8187,7 +6878,8 @@
             },
             "load-json-file": {
                "version": "4.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+               "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                "dev": true,
                "requires": {
                   "graceful-fs": "^4.1.2",
@@ -8198,7 +6890,8 @@
             },
             "locate-path": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                "dev": true,
                "requires": {
                   "p-locate": "^3.0.0",
@@ -8207,18 +6900,21 @@
             },
             "lodash.flattendeep": {
                "version": "4.4.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+               "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
                "dev": true
             },
             "longest": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+               "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
                "dev": true,
                "optional": true
             },
             "lru-cache": {
                "version": "4.1.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+               "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                "dev": true,
                "requires": {
                   "pseudomap": "^1.0.2",
@@ -8227,7 +6923,8 @@
             },
             "make-dir": {
                "version": "1.3.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+               "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
                "dev": true,
                "requires": {
                   "pify": "^3.0.0"
@@ -8235,7 +6932,8 @@
             },
             "md5-hex": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
+               "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
                "dev": true,
                "requires": {
                   "md5-o-matic": "^0.1.1"
@@ -8243,12 +6941,14 @@
             },
             "md5-o-matic": {
                "version": "0.1.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+               "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
                "dev": true
             },
             "mem": {
                "version": "1.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+               "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
                "dev": true,
                "requires": {
                   "mimic-fn": "^1.0.0"
@@ -8256,7 +6956,8 @@
             },
             "merge-source-map": {
                "version": "1.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
+               "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
                "dev": true,
                "requires": {
                   "source-map": "^0.6.1"
@@ -8264,19 +6965,22 @@
                "dependencies": {
                   "source-map": {
                      "version": "0.6.1",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                      "dev": true
                   }
                }
             },
             "mimic-fn": {
                "version": "1.2.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+               "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
                "dev": true
             },
             "minimatch": {
                "version": "3.0.4",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                "dev": true,
                "requires": {
                   "brace-expansion": "^1.1.7"
@@ -8284,12 +6988,14 @@
             },
             "minimist": {
                "version": "0.0.10",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+               "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
                "dev": true
             },
             "mkdirp": {
                "version": "0.5.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                "dev": true,
                "requires": {
                   "minimist": "0.0.8"
@@ -8297,19 +7003,22 @@
                "dependencies": {
                   "minimist": {
                      "version": "0.0.8",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                      "dev": true
                   }
                }
             },
             "ms": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
                "dev": true
             },
             "normalize-package-data": {
                "version": "2.4.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+               "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
                "dev": true,
                "requires": {
                   "hosted-git-info": "^2.1.4",
@@ -8320,7 +7029,8 @@
             },
             "npm-run-path": {
                "version": "2.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+               "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
                "dev": true,
                "requires": {
                   "path-key": "^2.0.0"
@@ -8328,12 +7038,14 @@
             },
             "number-is-nan": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
                "dev": true
             },
             "once": {
                "version": "1.4.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                "dev": true,
                "requires": {
                   "wrappy": "1"
@@ -8341,7 +7053,8 @@
             },
             "optimist": {
                "version": "0.6.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+               "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                "dev": true,
                "requires": {
                   "minimist": "~0.0.1",
@@ -8350,12 +7063,14 @@
             },
             "os-homedir": {
                "version": "1.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+               "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
                "dev": true
             },
             "os-locale": {
                "version": "2.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+               "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                "dev": true,
                "requires": {
                   "execa": "^0.7.0",
@@ -8365,12 +7080,14 @@
             },
             "p-finally": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+               "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
                "dev": true
             },
             "p-limit": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+               "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
                "dev": true,
                "requires": {
                   "p-try": "^2.0.0"
@@ -8378,7 +7095,8 @@
             },
             "p-locate": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                "dev": true,
                "requires": {
                   "p-limit": "^2.0.0"
@@ -8386,12 +7104,14 @@
             },
             "p-try": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+               "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
                "dev": true
             },
             "package-hash": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+               "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
                "dev": true,
                "requires": {
                   "graceful-fs": "^4.1.11",
@@ -8402,7 +7122,8 @@
             },
             "parse-json": {
                "version": "4.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+               "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                "dev": true,
                "requires": {
                   "error-ex": "^1.3.1",
@@ -8411,22 +7132,26 @@
             },
             "path-exists": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                "dev": true
             },
             "path-is-absolute": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+               "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                "dev": true
             },
             "path-key": {
                "version": "2.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+               "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
                "dev": true
             },
             "path-type": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+               "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                "dev": true,
                "requires": {
                   "pify": "^3.0.0"
@@ -8434,12 +7159,14 @@
             },
             "pify": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                "dev": true
             },
             "pkg-dir": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+               "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
                "dev": true,
                "requires": {
                   "find-up": "^3.0.0"
@@ -8447,12 +7174,14 @@
             },
             "pseudomap": {
                "version": "1.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+               "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
                "dev": true
             },
             "read-pkg": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+               "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                "dev": true,
                "requires": {
                   "load-json-file": "^4.0.0",
@@ -8462,7 +7191,8 @@
             },
             "read-pkg-up": {
                "version": "4.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+               "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
                "dev": true,
                "requires": {
                   "find-up": "^3.0.0",
@@ -8471,7 +7201,8 @@
             },
             "release-zalgo": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+               "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
                "dev": true,
                "requires": {
                   "es6-error": "^4.0.1"
@@ -8479,28 +7210,33 @@
             },
             "repeat-string": {
                "version": "1.6.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+               "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
                "dev": true,
                "optional": true
             },
             "require-directory": {
                "version": "2.1.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+               "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
                "dev": true
             },
             "require-main-filename": {
                "version": "1.0.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+               "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                "dev": true
             },
             "resolve-from": {
                "version": "4.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+               "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
                "dev": true
             },
             "right-align": {
                "version": "0.1.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+               "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -8509,7 +7245,8 @@
             },
             "rimraf": {
                "version": "2.6.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+               "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
                "dev": true,
                "requires": {
                   "glob": "^7.0.5"
@@ -8517,22 +7254,26 @@
             },
             "safe-buffer": {
                "version": "5.1.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                "dev": true
             },
             "semver": {
                "version": "5.5.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+               "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
                "dev": true
             },
             "set-blocking": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+               "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
                "dev": true
             },
             "shebang-command": {
                "version": "1.2.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+               "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
                "dev": true,
                "requires": {
                   "shebang-regex": "^1.0.0"
@@ -8540,23 +7281,27 @@
             },
             "shebang-regex": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+               "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                "dev": true
             },
             "signal-exit": {
                "version": "3.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+               "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
                "dev": true
             },
             "source-map": {
                "version": "0.5.7",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+               "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                "dev": true,
                "optional": true
             },
             "spawn-wrap": {
                "version": "1.4.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
+               "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
                "dev": true,
                "requires": {
                   "foreground-child": "^1.5.6",
@@ -8569,7 +7314,8 @@
             },
             "spdx-correct": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+               "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
                "dev": true,
                "requires": {
                   "spdx-expression-parse": "^3.0.0",
@@ -8578,12 +7324,14 @@
             },
             "spdx-exceptions": {
                "version": "2.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+               "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
                "dev": true
             },
             "spdx-expression-parse": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+               "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
                "dev": true,
                "requires": {
                   "spdx-exceptions": "^2.1.0",
@@ -8592,12 +7340,14 @@
             },
             "spdx-license-ids": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+               "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
                "dev": true
             },
             "string-width": {
                "version": "2.1.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                "dev": true,
                "requires": {
                   "is-fullwidth-code-point": "^2.0.0",
@@ -8606,7 +7356,8 @@
             },
             "strip-ansi": {
                "version": "4.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                "dev": true,
                "requires": {
                   "ansi-regex": "^3.0.0"
@@ -8614,17 +7365,20 @@
             },
             "strip-bom": {
                "version": "3.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+               "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
                "dev": true
             },
             "strip-eof": {
                "version": "1.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+               "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
                "dev": true
             },
             "supports-color": {
                "version": "5.4.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+               "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                "dev": true,
                "requires": {
                   "has-flag": "^3.0.0"
@@ -8632,7 +7386,8 @@
             },
             "test-exclude": {
                "version": "5.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.0.0.tgz",
+               "integrity": "sha512-bO3Lj5+qFa9YLfYW2ZcXMOV1pmQvw+KS/DpjqhyX6Y6UZ8zstpZJ+mA2ERkXfpOqhxsJlQiLeVXD3Smsrs6oLw==",
                "dev": true,
                "requires": {
                   "arrify": "^1.0.1",
@@ -8643,7 +7398,8 @@
             },
             "uglify-js": {
                "version": "2.8.29",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+               "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                "dev": true,
                "optional": true,
                "requires": {
@@ -8654,7 +7410,8 @@
                "dependencies": {
                   "yargs": {
                      "version": "3.10.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                      "dev": true,
                      "optional": true,
                      "requires": {
@@ -8668,18 +7425,21 @@
             },
             "uglify-to-browserify": {
                "version": "1.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+               "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                "dev": true,
                "optional": true
             },
             "uuid": {
                "version": "3.3.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+               "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
                "dev": true
             },
             "validate-npm-package-license": {
                "version": "3.0.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+               "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
                "dev": true,
                "requires": {
                   "spdx-correct": "^3.0.0",
@@ -8688,7 +7448,8 @@
             },
             "which": {
                "version": "1.3.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+               "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                "dev": true,
                "requires": {
                   "isexe": "^2.0.0"
@@ -8696,23 +7457,27 @@
             },
             "which-module": {
                "version": "2.0.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+               "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
                "dev": true
             },
             "window-size": {
                "version": "0.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+               "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                "dev": true,
                "optional": true
             },
             "wordwrap": {
                "version": "0.0.3",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+               "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
                "dev": true
             },
             "wrap-ansi": {
                "version": "2.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+               "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                "dev": true,
                "requires": {
                   "string-width": "^1.0.1",
@@ -8721,12 +7486,14 @@
                "dependencies": {
                   "ansi-regex": {
                      "version": "2.1.1",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                      "dev": true
                   },
                   "is-fullwidth-code-point": {
                      "version": "1.0.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                      "dev": true,
                      "requires": {
                         "number-is-nan": "^1.0.0"
@@ -8734,7 +7501,8 @@
                   },
                   "string-width": {
                      "version": "1.0.2",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                      "dev": true,
                      "requires": {
                         "code-point-at": "^1.0.0",
@@ -8744,7 +7512,8 @@
                   },
                   "strip-ansi": {
                      "version": "3.0.1",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                      "dev": true,
                      "requires": {
                         "ansi-regex": "^2.0.0"
@@ -8754,12 +7523,14 @@
             },
             "wrappy": {
                "version": "1.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                "dev": true
             },
             "write-file-atomic": {
                "version": "2.3.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+               "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
                "dev": true,
                "requires": {
                   "graceful-fs": "^4.1.11",
@@ -8769,17 +7540,20 @@
             },
             "y18n": {
                "version": "3.2.1",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+               "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
                "dev": true
             },
             "yallist": {
                "version": "2.1.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+               "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
                "dev": true
             },
             "yargs": {
                "version": "11.1.0",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+               "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
                "dev": true,
                "requires": {
                   "cliui": "^4.0.0",
@@ -8798,7 +7572,8 @@
                "dependencies": {
                   "cliui": {
                      "version": "4.1.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                      "dev": true,
                      "requires": {
                         "string-width": "^2.1.1",
@@ -8808,7 +7583,8 @@
                   },
                   "find-up": {
                      "version": "2.1.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                      "dev": true,
                      "requires": {
                         "locate-path": "^2.0.0"
@@ -8816,7 +7592,8 @@
                   },
                   "locate-path": {
                      "version": "2.0.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                      "dev": true,
                      "requires": {
                         "p-locate": "^2.0.0",
@@ -8825,7 +7602,8 @@
                   },
                   "p-limit": {
                      "version": "1.3.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                      "dev": true,
                      "requires": {
                         "p-try": "^1.0.0"
@@ -8833,7 +7611,8 @@
                   },
                   "p-locate": {
                      "version": "2.0.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                      "dev": true,
                      "requires": {
                         "p-limit": "^1.1.0"
@@ -8841,14 +7620,16 @@
                   },
                   "p-try": {
                      "version": "1.0.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                     "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
                      "dev": true
                   }
                }
             },
             "yargs-parser": {
                "version": "9.0.2",
-               "bundled": true,
+               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                "dev": true,
                "requires": {
                   "camelcase": "^4.1.0"
@@ -8856,7 +7637,8 @@
                "dependencies": {
                   "camelcase": {
                      "version": "4.1.0",
-                     "bundled": true,
+                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                      "dev": true
                   }
                }
@@ -8961,39 +7743,6 @@
             "wrappy": "1"
          }
       },
-      "onetime": {
-         "version": "2.0.1",
-         "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-         "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-         "dev": true,
-         "requires": {
-            "mimic-fn": "^1.0.0"
-         }
-      },
-      "optimist": {
-         "version": "0.6.1",
-         "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-         "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-         "dev": true,
-         "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
-         },
-         "dependencies": {
-            "minimist": {
-               "version": "0.0.10",
-               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-               "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-               "dev": true
-            },
-            "wordwrap": {
-               "version": "0.0.3",
-               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-               "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-               "dev": true
-            }
-         }
-      },
       "optionator": {
          "version": "0.8.3",
          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
@@ -9014,66 +7763,6 @@
          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
          "dev": true
       },
-      "os-locale": {
-         "version": "3.1.0",
-         "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-         "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-         "dev": true,
-         "requires": {
-            "execa": "^1.0.0",
-            "lcid": "^2.0.0",
-            "mem": "^4.0.0"
-         },
-         "dependencies": {
-            "cross-spawn": {
-               "version": "6.0.5",
-               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-               "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-               "dev": true,
-               "requires": {
-                  "nice-try": "^1.0.4",
-                  "path-key": "^2.0.1",
-                  "semver": "^5.5.0",
-                  "shebang-command": "^1.2.0",
-                  "which": "^1.2.9"
-               }
-            },
-            "execa": {
-               "version": "1.0.0",
-               "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-               "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-               "dev": true,
-               "requires": {
-                  "cross-spawn": "^6.0.0",
-                  "get-stream": "^4.0.0",
-                  "is-stream": "^1.1.0",
-                  "npm-run-path": "^2.0.0",
-                  "p-finally": "^1.0.0",
-                  "signal-exit": "^3.0.0",
-                  "strip-eof": "^1.0.0"
-               }
-            },
-            "get-stream": {
-               "version": "4.1.0",
-               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-               "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-               "dev": true,
-               "requires": {
-                  "pump": "^3.0.0"
-               }
-            },
-            "pump": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-               "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-               "dev": true,
-               "requires": {
-                  "end-of-stream": "^1.1.0",
-                  "once": "^1.3.1"
-               }
-            }
-         }
-      },
       "os-tmpdir": {
          "version": "1.0.2",
          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -9089,24 +7778,6 @@
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
          }
-      },
-      "p-defer": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-         "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-         "dev": true
-      },
-      "p-finally": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-         "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-         "dev": true
-      },
-      "p-is-promise": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
-         "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg==",
-         "dev": true
       },
       "p-limit": {
          "version": "1.3.0",
@@ -9357,12 +8028,6 @@
             "map-cache": "^0.2.0",
             "path-root": "^0.1.1"
          }
-      },
-      "parse-github-repo-url": {
-         "version": "1.4.1",
-         "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-         "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
-         "dev": true
       },
       "parse-json": {
          "version": "4.0.0",
@@ -9669,12 +8334,6 @@
          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
          "dev": true
       },
-      "quick-lru": {
-         "version": "1.1.0",
-         "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-         "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-         "dev": true
-      },
       "raw-body": {
          "version": "1.1.7",
          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
@@ -9737,23 +8396,6 @@
          "requires": {
             "resolve": "^1.1.6"
          }
-      },
-      "redent": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-         "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-         "dev": true,
-         "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-         }
-      },
-      "regenerator-runtime": {
-         "version": "0.11.1",
-         "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-         "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-         "dev": true,
-         "optional": true
       },
       "regex-not": {
          "version": "1.0.2",
@@ -9861,12 +8503,6 @@
          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
          "dev": true
       },
-      "require-main-filename": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-         "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-         "dev": true
-      },
       "resolve": {
          "version": "1.10.0",
          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
@@ -9907,16 +8543,6 @@
          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
          "dev": true
       },
-      "restore-cursor": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-         "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-         "dev": true,
-         "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-         }
-      },
       "ret": {
          "version": "0.1.15",
          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -9929,12 +8555,6 @@
          "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
          "dev": true
       },
-      "right-pad": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/right-pad/-/right-pad-1.0.1.tgz",
-         "integrity": "sha1-jKCMLLtbVedNr6lr9/0aJ9VoyNA=",
-         "dev": true
-      },
       "rimraf": {
          "version": "2.6.3",
          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -9942,15 +8562,6 @@
          "dev": true,
          "requires": {
             "glob": "^7.1.3"
-         }
-      },
-      "run-async": {
-         "version": "2.3.0",
-         "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
-         "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-         "dev": true,
-         "requires": {
-            "is-promise": "^2.1.0"
          }
       },
       "run-con": {
@@ -9972,9 +8583,9 @@
                "dev": true
             },
             "minimist": {
-               "version": "1.2.5",
-               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-               "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+               "version": "1.2.6",
+               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+               "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
                "dev": true
             },
             "strip-json-comments": {
@@ -9990,15 +8601,6 @@
          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
          "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
          "dev": true
-      },
-      "rxjs": {
-         "version": "6.5.4",
-         "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
-         "integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
-         "dev": true,
-         "requires": {
-            "tslib": "^1.9.0"
-         }
       },
       "safe-buffer": {
          "version": "5.1.2",
@@ -10039,12 +8641,6 @@
          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
          "dev": true
       },
-      "set-blocking": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-         "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-         "dev": true
-      },
       "set-value": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -10082,17 +8678,6 @@
          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
          "dev": true
-      },
-      "shelljs": {
-         "version": "0.7.6",
-         "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-         "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
-         "dev": true,
-         "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
-         }
       },
       "signal-exit": {
          "version": "3.0.2",
@@ -10347,15 +8932,6 @@
             "extend-shallow": "^3.0.0"
          }
       },
-      "split2": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-         "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-         "dev": true,
-         "requires": {
-            "through2": "^2.0.2"
-         }
-      },
       "sprintf-js": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -10377,39 +8953,6 @@
             "jsbn": "~0.1.0",
             "safer-buffer": "^2.0.2",
             "tweetnacl": "~0.14.0"
-         }
-      },
-      "standard-version": {
-         "version": "5.0.2",
-         "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-5.0.2.tgz",
-         "integrity": "sha512-vvdWZySinwWU9UZhtgYUGGTkYzqrwYMw3c7CFJ17E7vMbAEqVSui/bm+ZcSukAAU2WmphPTWIKFmn8ni+lk4NA==",
-         "dev": true,
-         "requires": {
-            "chalk": "^2.4.1",
-            "conventional-changelog": "^3.0.6",
-            "conventional-recommended-bump": "^4.0.4",
-            "detect-indent": "^5.0.0",
-            "detect-newline": "^2.1.0",
-            "dotgitignore": "^2.1.0",
-            "figures": "^2.0.0",
-            "fs-access": "^1.0.0",
-            "git-semver-tags": "^2.0.2",
-            "semver": "^5.2.0",
-            "stringify-package": "^1.0.0",
-            "yargs": "^12.0.2"
-         },
-         "dependencies": {
-            "chalk": {
-               "version": "2.4.2",
-               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-               "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-               "dev": true,
-               "requires": {
-                  "ansi-styles": "^3.2.1",
-                  "escape-string-regexp": "^1.0.5",
-                  "supports-color": "^5.3.0"
-               }
-            }
          }
       },
       "static-extend": {
@@ -10445,16 +8988,6 @@
          "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
          "dev": true
       },
-      "string-width": {
-         "version": "2.1.1",
-         "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-         "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-         "dev": true,
-         "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-         }
-      },
       "string_decoder": {
          "version": "1.1.1",
          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -10464,43 +8997,16 @@
             "safe-buffer": "~5.1.0"
          }
       },
-      "stringify-package": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.0.tgz",
-         "integrity": "sha512-JIQqiWmLiEozOC0b0BtxZ/AOUtdUZHCBPgqIZ2kSJJqGwgb9neo44XdTHUC4HZSGqi03hOeB7W/E8rAlKnGe9g==",
-         "dev": true
-      },
-      "strip-ansi": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-         "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-         "dev": true,
-         "requires": {
-            "ansi-regex": "^3.0.0"
-         }
-      },
       "strip-bom": {
          "version": "3.0.0",
          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
          "dev": true
       },
-      "strip-eof": {
-         "version": "1.0.0",
-         "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-         "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-         "dev": true
-      },
       "strip-final-newline": {
          "version": "2.0.0",
          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
          "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-         "dev": true
-      },
-      "strip-indent": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-         "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
          "dev": true
       },
       "strip-json-comments": {
@@ -10791,12 +9297,6 @@
                "requires": {
                   "p-locate": "^4.1.0"
                }
-            },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
             },
             "map-obj": {
                "version": "4.3.0",
@@ -11113,14 +9613,6 @@
             "postcss-resolve-nested-selector": "^0.1.1",
             "postcss-selector-parser": "^6.0.2",
             "postcss-value-parser": "^4.1.0"
-         },
-         "dependencies": {
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            }
          }
       },
       "sugarss": {
@@ -11169,12 +9661,6 @@
                "version": "7.0.3",
                "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
                "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-               "dev": true
-            },
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
                "dev": true
             },
             "string-width": {
@@ -11325,18 +9811,6 @@
             "punycode": "^2.1.1"
          }
       },
-      "trim-newlines": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-         "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-         "dev": true
-      },
-      "trim-off-newlines": {
-         "version": "1.0.1",
-         "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-         "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-         "dev": true
-      },
       "trim-right": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -11444,31 +9918,11 @@
          "dev": true
       },
       "uglify-js": {
-         "version": "3.5.0",
-         "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.0.tgz",
-         "integrity": "sha512-kY2sHdru6BcIDg+i1SCZ1bpPhZJ6yiE0bEKLEJDC4M/lDSMhr/zVJeuEzvHJGjAXJCizSzUVh9atREf2jnR7yQ==",
+         "version": "3.15.5",
+         "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.5.tgz",
+         "integrity": "sha512-hNM5q5GbBRB5xB+PMqVRcgYe4c8jbyZ1pzZhS6jbq54/4F2gFK869ZheiE5A8/t+W5jtTNpWef/5Q9zk639FNQ==",
          "dev": true,
-         "optional": true,
-         "requires": {
-            "commander": "~2.19.0",
-            "source-map": "~0.6.1"
-         },
-         "dependencies": {
-            "commander": {
-               "version": "2.19.0",
-               "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-               "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
-               "dev": true,
-               "optional": true
-            },
-            "source-map": {
-               "version": "0.6.1",
-               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-               "dev": true,
-               "optional": true
-            }
-         }
+         "optional": true
       },
       "unc-path-regex": {
          "version": "0.1.2",
@@ -11555,12 +10009,6 @@
          "requires": {
             "@types/unist": "^2.0.2"
          }
-      },
-      "universalify": {
-         "version": "0.1.2",
-         "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-         "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-         "dev": true
       },
       "unset-value": {
          "version": "1.0.0",
@@ -11716,12 +10164,6 @@
             "semver": "^6.3.0"
          },
          "dependencies": {
-            "lodash": {
-               "version": "4.17.21",
-               "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-               "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-               "dev": true
-            },
             "semver": {
                "version": "6.3.0",
                "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -11755,64 +10197,17 @@
             "isexe": "^2.0.0"
          }
       },
-      "which-module": {
-         "version": "2.0.0",
-         "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-         "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-         "dev": true
-      },
       "word-wrap": {
          "version": "1.2.3",
          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
          "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
          "dev": true
       },
-      "wrap-ansi": {
-         "version": "2.1.0",
-         "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-         "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-         "dev": true,
-         "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-         },
-         "dependencies": {
-            "ansi-regex": {
-               "version": "2.1.1",
-               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-               "dev": true
-            },
-            "is-fullwidth-code-point": {
-               "version": "1.0.0",
-               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-               "dev": true,
-               "requires": {
-                  "number-is-nan": "^1.0.0"
-               }
-            },
-            "string-width": {
-               "version": "1.0.2",
-               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-               "dev": true,
-               "requires": {
-                  "code-point-at": "^1.0.0",
-                  "is-fullwidth-code-point": "^1.0.0",
-                  "strip-ansi": "^3.0.0"
-               }
-            },
-            "strip-ansi": {
-               "version": "3.0.1",
-               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-               "dev": true,
-               "requires": {
-                  "ansi-regex": "^2.0.0"
-               }
-            }
-         }
+      "wordwrap": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+         "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+         "dev": true
       },
       "wrappy": {
          "version": "1.0.2",
@@ -11847,12 +10242,6 @@
          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
          "dev": true
       },
-      "y18n": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-         "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-         "dev": true
-      },
       "yallist": {
          "version": "4.0.0",
          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -11864,87 +10253,6 @@
          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
          "dev": true
-      },
-      "yargs": {
-         "version": "12.0.5",
-         "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-         "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-         "dev": true,
-         "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-         },
-         "dependencies": {
-            "camelcase": {
-               "version": "5.2.0",
-               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-               "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
-               "dev": true
-            },
-            "find-up": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-               "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-               "dev": true,
-               "requires": {
-                  "locate-path": "^3.0.0"
-               }
-            },
-            "locate-path": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-               "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-               "dev": true,
-               "requires": {
-                  "p-locate": "^3.0.0",
-                  "path-exists": "^3.0.0"
-               }
-            },
-            "p-limit": {
-               "version": "2.2.0",
-               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-               "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-               "dev": true,
-               "requires": {
-                  "p-try": "^2.0.0"
-               }
-            },
-            "p-locate": {
-               "version": "3.0.0",
-               "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-               "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-               "dev": true,
-               "requires": {
-                  "p-limit": "^2.0.0"
-               }
-            },
-            "p-try": {
-               "version": "2.1.0",
-               "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-               "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
-               "dev": true
-            },
-            "yargs-parser": {
-               "version": "11.1.1",
-               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-               "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-               "dev": true,
-               "requires": {
-                  "camelcase": "^5.0.0",
-                  "decamelize": "^1.2.0"
-               }
-            }
-         }
       },
       "yargs-parser": {
          "version": "20.2.9",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,13 @@
       "prepare": "grunt build",
       "test:node-version": "check-node-version --npm 6.14.12 --print",
       "test": "npm run test:node-version && TS_NODE_PROJECT='tests/tsconfig.json' TS_NODE_FILES=true nyc mocha --opts ./.mocha.opts",
+      "eslint": "eslint '{,!(node_modules|dist)/**/}*.js'",
+      "markdownlint": "markdownlint -c .markdownlint.json -i CHANGELOG.md '{,!(node_modules)/**/}*.md'",
       "commitlint": "commitlint --from 0b9d320",
-      "standards": "npm run commitlint && grunt standards"
+      "standards": "npm run markdownlint && npm run eslint",
+      "release:preview": "node ./node_modules/@silvermine/standardization/scripts/release.js preview",
+      "release:prep-changelog": "node ./node_modules/@silvermine/standardization/scripts/release.js prep-changelog",
+      "release:finalize": "node ./node_modules/@silvermine/standardization/scripts/release.js finalize"
    },
    "author": "Matt Luedke",
    "license": "MIT",
@@ -33,8 +38,8 @@
    "devDependencies": {
       "@silvermine/chai-strictly-equal": "1.1.0",
       "@silvermine/eslint-config": "3.1.0-beta.0",
-      "@silvermine/standardization": "1.2.1",
-      "@silvermine/typescript-config": "git+https://github.com/silvermine/typescript-config.git#23213e33077089e723629dead5342abe6f3b3c8c",
+      "@silvermine/standardization": "2.0.0",
+      "@silvermine/typescript-config": "git+https://github.com/silvermine/typescript-config#23213e33077089e723629dead5342abe6f3b3c8c",
       "@types/chai": "4.1.7",
       "@types/mocha": "5.2.5",
       "@types/node": "12.20.45",
@@ -42,28 +47,19 @@
       "chai": "4.2.0",
       "check-node-version": "4.0.2",
       "coveralls": "3.0.9",
-      "cz-conventional-changelog": "3.1.0",
       "eslint": "6.8.0",
       "grunt": "1.0.4",
       "grunt-cli": "1.3.2",
       "grunt-concurrent": "2.3.1",
       "grunt-contrib-clean": "2.0.0",
       "grunt-contrib-watch": "1.1.0",
-      "grunt-eslint": "24.0.0",
       "grunt-exec": "3.0.0",
       "mocha": "5.2.0",
       "nyc": "13.1.0",
       "sinon": "5.1.1",
       "source-map-support": "0.5.16",
-      "standard-version": "5.0.2",
       "ts-node": "7.0.1",
       "tslib": "1.9.3",
       "typescript": "3.9.5"
-   },
-   "dependencies": {},
-   "config": {
-      "commitizen": {
-         "path": "./node_modules/cz-conventional-changelog"
-      }
    }
 }


### PR DESCRIPTION
- also removes grunt-eslint + `grunt standards` as linting toolchain
- updates .travis-ci to use `focal` Ubuntu distribution
- removes a symlink to Standardization's `.nvmrc`