### PR TITLE
build: allow for broader versions of tslib peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "type guards"
    ],
    "peerDependencies": {
-      "tslib": "1.9.x"
+      "tslib": "^1.9.0"
    },
    "devDependencies": {
       "@silvermine/chai-strictly-equal": "1.1.0",


### PR DESCRIPTION
This package currently is not compatible with [another package that my project depends on](https://github.com/shiftcode/dynamo-easy/blob/1ff9814c775524dba6f1c5b324b5c249da2d1d20/package.json#L86). The change in this MR should allow the toolbox to work with a broader number of other packages that list `tslib` as a peer dependency.